### PR TITLE
Add injected object property wrapper

### DIFF
--- a/Sources/Factory/Factory.swift
+++ b/Sources/Factory/Factory.swift
@@ -276,6 +276,9 @@ extension SharedContainer.Scope {
     }
 }
 
+/// Convenience property wrapper takes a factory and creates an instance of the desired object that can be observed.
+/// This wrapper is meant for use in SwiftUI Views and exposes bindable objects similar to that of SwiftUI @observedObject and @environmentObject.
+/// Dependent service must be of type ObservableObject. Updating object state will trigger view update.
 @available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 @propertyWrapper public struct InjectedObject<T>: DynamicProperty where T: ObservableObject {
     @ObservedObject private var dependency: T

--- a/Sources/Factory/Factory.swift
+++ b/Sources/Factory/Factory.swift
@@ -25,6 +25,7 @@
 //
 
 import Foundation
+import SwiftUI
 
 /// Factory manages the dependency injection process for a given object or service.
 public struct Factory<T> {
@@ -274,6 +275,21 @@ extension SharedContainer.Scope {
         }
     }
 }
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+@propertyWrapper public struct InjectedObject<T>: DynamicProperty where T: ObservableObject {
+    @ObservedObject private var dependency: T
+
+    public init(_ factory: Factory<T>) {
+        self.dependency = factory()
+    }
+    public var wrappedValue: T {
+        get { return dependency }
+        mutating set { dependency = newValue }
+    }
+    public var projectedValue: ObservedObject<T>.Wrapper {
+        return self.$dependency
+    }
 #endif
 
 /// Resolving an instance of a service is a recursive process (service A needs a B which needs a C).


### PR DESCRIPTION
This request adds an 'InjectedObject' property wrapper to allow injection of an observable object.  
Basically the same wrapper than in resolver.