### PR TITLE
Fix distributing demo app as part of the package

### DIFF
--- a/FactoryDemo/Package.swift
+++ b/FactoryDemo/Package.swift
@@ -1,0 +1,4 @@
+// swift-tools-version: 5.6
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription


### PR DESCRIPTION
@hmlongco thanks for the great work on Factory.

This PR adds an empty `Package.swift` file to the demo app as a workaround to stop distributing it as part of the package (see screenshots below). It is not really needed, more a cosmetic/convenience change. Feel free to ignore this PR if you think it is unnecessary.

| Referencing `main`  | Referencing the branch from this PR |
| ------------- | ------------- |
| <img width="1552" alt="Screenshot 2022-10-23 at 20 44 18" src="https://user-images.githubusercontent.com/905292/197410395-81dbfa9c-7a6d-4ada-97e6-fc0e0dc81a47.png"> | <img width="1552" alt="Screenshot 2022-10-23 at 20 46 31" src="https://user-images.githubusercontent.com/905292/197410409-d83f32c5-92de-4ff2-a309-1cd8012a9c0b.png">  |

