### PR TITLE
Adding module name check to circular dependency chain detection

### DIFF
--- a/Sources/Factory/Factory.swift
+++ b/Sources/Factory/Factory.swift
@@ -430,7 +430,7 @@ private struct Registration<P, T> {
         let currentFactory: (P) -> T = (SharedContainer.Registrations.factory(for: id) as? TypedFactory<P, T>)?.factory ?? factory
 
         #if DEBUG
-        let typeComponents = String(describing: T.self).components(separatedBy: CharacterSet(charactersIn: "<>"))
+        let typeComponents = String(reflecting: T.self).components(separatedBy: CharacterSet(charactersIn: "<>"))
         let typeName = typeComponents.count > 1 ? typeComponents[1] : typeComponents[0]
         let typeIndex = globalDependencyChain.firstIndex(where: { $0 == typeName })
         globalDependencyChain.append(typeName)


### PR DESCRIPTION
This request adds module name check to circular dependency chain detection.
Factory had problems resolving internal classes with the same name but belonging to different modules. 
Eg. Module 'A' resolve class named 'Foo', module 'B' resolve class named 'Foo'.
Your code detects a dependency between A.Foo and B.Foo as it doesn't verify that they have different module names.