### PR TITLE
Fixing release compilation

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/Factory.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Factory.xcscheme
@@ -22,10 +22,10 @@
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "YES"
+            buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "FactoryTests"

--- a/Sources/Factory/Factory.swift
+++ b/Sources/Factory/Factory.swift
@@ -470,6 +470,7 @@ public class ContainerManager {
     /// Public variable exposing dependency chain test maximum
     public var dependencyChainTestMax: Int = 10
 
+    #if DEBUG
     /// Public var enabling factory resolution trace statements in debug mode for ALL containers.
     public var trace: Bool {
         get { globalTraceFlag }
@@ -481,6 +482,7 @@ public class ContainerManager {
         get { globalLogger }
         set { globalLogger = newValue }
     }
+    #endif
 
     /// Internal closure decorates all factory resolutions for this container.
     internal var decorator: ((Any) -> ())?


### PR DESCRIPTION
Was attempting to profile my app for another problem this morning and it would not compile due to a missing `#if DEBUG - #endif` wrapper in Factory. This PR adds that wrapper. 

PS> I'm using the `develop` branch because I read that it will be released soon. Please let me know if this is not correct and I'll switch to `main`. My app is planned to be released in a few months time so I thought I'd use the latest and greatest :-).