### PR TITLE
Update Competition.md

### DIFF
--- a/Sources/Factory/Factory.docc/Additional/Competition.md
+++ b/Sources/Factory/Factory.docc/Additional/Competition.md
@@ -93,9 +93,6 @@ func testAdd() async throws {
     // test the model
 }
 ```
-As shown, one can use this and other strategies to update the dependencies on `FeatureModel`. It doesn't, however, let you reach deeper into the dependency tree and change a dependency inside of a dependency inside of a dependency like you can with Factory.
-
-Further, note that in order to mutate the `FeatureModel` the api parameter can not be private. It must be expeosed to the outside world.
 
 ## Compile-Time Libraries
 


### PR DESCRIPTION
Hi there, we noticed that our library [swift-dependencies](http://github.com/pointfreeco/swift-dependencies) was mentioned in your "Competition" article, and we feel there may be some misunderstandings in it. We'd like to offer some explanations and ask if you would consider updating the article.

For this section:

> As shown, one can use this and other strategies to update the dependencies on `FeatureModel`. It doesn't, however, let you reach deeper into the dependency tree and change a dependency inside of a dependency inside of a dependency like you can with Factory.

This is not true. Dependencies of dependencies can be controlled, and we have a [full test suite](https://github.com/pointfreeco/swift-dependencies/blob/aa3bf22d6f3e6fcb8f3d8e1e84db379daa364871/Tests/DependenciesTests/ResolutionTests.swift) showing it. If a dependency wants to use a dependency it can do so via `@Dependency`, and overriding dependencies using `withDependencies` goes through all layers of the tree.

And for this section:

> Further, note that in order to mutate the `FeatureModel` the api parameter can not be private. It must be expeosed to the outside world.

This is also not true. It is completely fine to do:

```swift
@Dependency(\.apiClient) private var api
```

The mutation happening inside `withDependencies` is not on the model, but rather `DependencyValues` which acts as the global storage of the current dependencies. So all of the dependencies in a model can be private.
