### PR TITLE
Refactor getting a factory given the context

### DIFF
--- a/Sources/Factory/Factory/Registrations.swift
+++ b/Sources/Factory/Factory/Registrations.swift
@@ -170,12 +170,9 @@ public struct FactoryRegistration<P,T> {
     }
 
     private func getFactory(argumentContexts: [String : AnyFactory]) -> ((P) -> T)? {
-        for arg in FactoryContext.arguments {
-            if let found = argumentContexts[arg] as? TypedFactory<P,T> {
-                return found.factory
-            }
-        }
-        for (_, arg) in FactoryContext.runtimeArguments {
+        let arguments = FactoryContext.arguments + FactoryContext.runtimeArguments.values
+
+        for arg in arguments {
             if let found = argumentContexts[arg] as? TypedFactory<P,T> {
                 return found.factory
             }


### PR DESCRIPTION
Functionally nothing changed just the early exit pattern with lots of ifs is split into multiple functions.

This is so the intention and hierarchy of how a context would map to a factory would be clear while reading the function.