### PR TITLE
Add resolve context to overrule the context at resolution time

### DIFF
--- a/Sources/Factory/Factory/Contexts.swift
+++ b/Sources/Factory/Factory/Contexts.swift
@@ -42,6 +42,45 @@ public enum FactoryContext: Equatable {
     case simulator
     /// Context used when application is running on an actual device.
     case device
+
+    var arguments: [String]? {
+        switch self {
+            case .arg(let arg): return [arg]
+            case .args(let args): return args
+            default: return nil
+        }
+    }
+
+    var isPreview: Bool {
+        switch self {
+            case .preview: return true
+            default: return false
+        }
+    }
+    var isTest: Bool {
+        switch self {
+            case .test: return true
+            default: return false
+        }
+    }
+    var debug: Bool {
+        switch self {
+            case .debug: return true
+            default: return false
+        }
+    }
+    var simulator: Bool {
+        switch self {
+            case .simulator: return true
+            default: return false
+        }
+    }
+    var device: Bool {
+        switch self {
+            case .device: return true
+            default: return false
+        }
+    }
 }
 
 extension FactoryContext {

--- a/Sources/Factory/Factory/Factory.swift
+++ b/Sources/Factory/Factory/Factory.swift
@@ -110,6 +110,10 @@ public struct Factory<T>: FactoryModifying {
         registration.resolve(with: ())
     }
 
+    public func resolve(in context: FactoryContext) -> T {
+        registration.resolve(with: (), resolveContext: context)
+    }
+
     /// Registers a new factory closure capable of producing an object or service of the desired type.
     ///
     /// This factory overrides the original factory closure and clears the associated scope so that the next time this factory is resolved

--- a/Tests/FactoryTests/FactoryContextTests.swift
+++ b/Tests/FactoryTests/FactoryContextTests.swift
@@ -291,6 +291,20 @@ final class FactoryContextTests: XCTestCase {
         XCTAssertEqual(service2.name, "CHANGED")
     }
 
+    func testResolveInContext() {
+        XCTAssertEqual(Container.shared.foo.resolve(), "no arg")
+        XCTAssertEqual(Container.shared.foo.resolve(in: .arg("with arg")), "with arg")
+        XCTAssertEqual(Container.shared.foo.resolve(in: .args(["with arg"])), "with arg")
+        XCTAssertEqual(Container.shared.foo.resolve(in: .preview), "preview")
+        XCTAssertEqual(Container.shared.foo.resolve(), "no arg")
+
+        // set stuff that is set based on the build context
+        Container.shared.foo.onTest { "test"}
+        Container.shared.foo.onDevice { "device"}
+
+        XCTAssertEqual(Container.shared.foo.resolve(), "test")
+    }
+
 }
 
 struct ContextService {
@@ -298,6 +312,12 @@ struct ContextService {
 }
 
 extension Container {
+    fileprivate var foo: Factory<String> {
+        self { "no arg" }
+            .onArg("with arg") { "with arg"}
+            .onPreview { "preview" }
+    }
+
     fileprivate var externalContextService: Factory<ContextService> {
         self { ContextService(name: "FACTORY") }
     }


### PR DESCRIPTION
For my project it is very important that there is one global context that all registrations use and a resolve context that I can use to force a resolution to take a factory context into account. I hope we can at least discuss the option of adding this feature. Maybe the implementation is not as you would like it to be in Factory but could you point me into a direction or should I remain on a fork?

I tried to prepare for this merge request by first refactoring the way a context was used to look for the appropriate factory in #105 but that request was closed and I was pointed to develop. I removed the need to refactor the code but just add the feature.

The added unit tests` FactoryContextTests.swift:294  testResolveInContext()` should clarify how it can be used.

> Question: I also notice that develop does not seam to be up to date with main. So unclear if I should point this to main or develop?