### PR TITLE
fix FactoryContext not public

### DIFF
--- a/Sources/Factory/Factory/Contexts.swift
+++ b/Sources/Factory/Factory/Contexts.swift
@@ -44,7 +44,7 @@ public enum FactoryContextType: Equatable {
     case device
 }
 
-struct FactoryContext {
+public struct FactoryContext {
     /// Proxy for application arguments.
     public var arguments: [String] = ProcessInfo.processInfo.arguments
     /// Runtime arguments


### PR DESCRIPTION
In order to change the context global I should
use FactoryContext.setArg("light", forKey: "theme") but as the type is not public this is not possible

> Note: Strange to me that you can have a publis current
shared context object with a non public type. The compiler should fail no?