### PR TITLE
Adds Swift Package Index manifest

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,4 @@
+version: 1
+builder:
+  configs:
+    - documentation_targets: [Factory]


### PR DESCRIPTION
This adds the `.spi.yml` which is used by Swift Package Index CI to build documentations directly in their website.