### PR TITLE
Removed empty Package.swift at FactoryDemo

### DIFF
--- a/FactoryDemo/Package.swift
+++ b/FactoryDemo/Package.swift
@@ -1,4 +1,0 @@
-// swift-tools-version: 5.6
-// The swift-tools-version declares the minimum version of Swift required to build this package.
-
-import PackageDescription


### PR DESCRIPTION
This removes an empty `Package.swift` swift file which has no reason to exist.