### PR TITLE
Cleanup minimum requirements for Apple Platforms

### DIFF
--- a/Factory.podspec
+++ b/Factory.podspec
@@ -7,10 +7,17 @@ Pod::Spec.new do |s|
   s.author       = "Michael Long"
   s.source       = { :git => "https://github.com/hmlongco/Factory.git", :tag => "#{s.version}" }
   s.source_files  = "Sources/**/*.swift"
-  s.swift_version = '5.6'
+  s.swift_version = '5.7'
 
   s.ios.deployment_target = "11.0"
-  s.tvos.deployment_target = "13.0"
-  s.watchos.deployment_target = "8.2"
-  s.osx.deployment_target = "10.14"
+  s.ios.framework = 'UIKit'
+
+  s.tvos.deployment_target = "11.0"
+  s.ios.framework = 'UIKit'
+
+  s.watchos.deployment_target = "4.0"
+  s.ios.framework = 'SwiftUI'
+
+  s.osx.deployment_target = "10.13"
+  s.osx.framework = 'AppKit'
 end

--- a/Factory.podspec
+++ b/Factory.podspec
@@ -6,18 +6,11 @@ Pod::Spec.new do |s|
   s.license      = "MIT"
   s.author       = "Michael Long"
   s.source       = { :git => "https://github.com/hmlongco/Factory.git", :tag => "#{s.version}" }
-  s.source_files  = "Classes", "Sources/**/*.swift"
-  s.swift_version = '5.1'
+  s.source_files  = "Sources/**/*.swift"
+  s.swift_version = '5.6'
 
   s.ios.deployment_target = "11.0"
-  s.ios.framework  = 'UIKit'
-
   s.tvos.deployment_target = "13.0"
-  s.tvos.framework  = 'UIKit'
-
   s.watchos.deployment_target = "8.2"
-  s.watchos.framework  = 'SwiftUI'
-
   s.osx.deployment_target = "10.14"
-  s.osx.framework  = 'AppKit'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.6
+// swift-tools-version: 5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -5,12 +5,6 @@ import PackageDescription
 
 let package = Package(
     name: "Factory",
-    platforms: [
-        .iOS(.v11),
-        .macOS(.v10_14),
-        .tvOS(.v13),
-        .watchOS(.v8)
-    ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,8 +1,0 @@
-import XCTest
-
-import FactoryTests
-
-var tests = [XCTestCaseEntry]()
-tests += FactoryTests.__allTests()
-
-XCTMain(tests)


### PR DESCRIPTION
Since Factory doesn't use any code that is restricted to iOS, macOS, tvOS and watchOS versions, there's no need to specify the base versions. This will make Factory available for all platforms.

Also I removed the LinuxMain which is not required anymore since Swift 5.4

The last updates I've made was in the `.podspec` that contains some statements that aren't required.