### PR TITLE
Cleanup some compilation conditionals

### DIFF
--- a/Sources/Factory/Factory/Injections.swift
+++ b/Sources/Factory/Factory/Injections.swift
@@ -30,8 +30,6 @@ import Foundation
 import SwiftUI
 #endif
 
-#if swift(>=5.1)
-
 /// Convenience property wrapper takes a factory and resolves an instance of the desired type.
 ///
 /// Property wrappers implement an annotation pattern to resolving dependencies, similar to using
@@ -273,7 +271,7 @@ import SwiftUI
     }
 }
 
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if canImport(Darwin)
 /// Immediate injection property wrapper for SwiftUI ObservableObjects.
 ///
 /// This wrapper is meant for use in SwiftUI Views and exposes bindable objects similar to that of SwiftUI @StateObject
@@ -349,5 +347,3 @@ internal struct FactoryReference<C: SharedContainer, R>: BoxedFactoryReference {
         C.shared[keyPath: keypath] as! Factory<T>
     }
 }
-
-#endif

--- a/Sources/Factory/Factory/Injections.swift
+++ b/Sources/Factory/Factory/Injections.swift
@@ -271,7 +271,7 @@ import SwiftUI
     }
 }
 
-#if canImport(Darwin)
+#if canImport(SwiftUI)
 /// Immediate injection property wrapper for SwiftUI ObservableObjects.
 ///
 /// This wrapper is meant for use in SwiftUI Views and exposes bindable objects similar to that of SwiftUI @StateObject


### PR DESCRIPTION
Removed the `if swift(>=5.1)` because the minimum for Factory is `5.6`. Also, I've updated the `#if os(...)` to `#if canImport(SwiftUI)` to extends support for visionOS too.