### PR TITLE
Fixed reference to shared manager in test example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ final class FactoryCoreTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        Container.shared.reset()
+        Container.shared.manager.reset()
     }
     
     func testLoaded() throws {


### PR DESCRIPTION
I copied the code and noticed it didn't work.