### PR TITLE
Added privacy manifest file

### DIFF
--- a/Factory.podspec
+++ b/Factory.podspec
@@ -7,6 +7,7 @@ Pod::Spec.new do |s|
   s.author       = "Michael Long"
   s.source       = { :git => "https://github.com/hmlongco/Factory.git", :tag => "#{s.version}" }
   s.source_files  = "Sources/**/*.swift"
+  s.resources     = "Sources/**/*.xcprivacy"
   s.swift_version = '5.7'
 
   s.ios.deployment_target = "12.0"

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,8 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "Factory",
-            dependencies: []),
+            dependencies: [],
+            resources: [.copy("PrivacyInfo.xcprivacy")]),
         .testTarget(
             name: "FactoryTests",
             dependencies: ["Factory"]),

--- a/Sources/Factory/PrivacyInfo.xcprivacy
+++ b/Sources/Factory/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSPrivacyTracking</key>
+    <false/>
+    <key>NSPrivacyTrackingDomains</key>
+    <array/>
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>


### PR DESCRIPTION
As mentioned in #177 starting from spring 2024 apple requires app and third party SDKs to include a privacy manifest file. It's unclear whether also third party SDKs which are not making use of privacy sensitive API must include such manifest file, although it doesn't hurt adding an empty one (e.g. https://github.com/realm/realm-swift/commit/8c1d9a732040c3ce43fb43532d47f871bfb9cda2).

https://developer.apple.com/documentation/bundleresources/privacy_manifest_files
https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api