### PR TITLE
Add visionOS to package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.6
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,10 +6,11 @@ import PackageDescription
 let package = Package(
     name: "Factory",
     platforms: [
-        .iOS(.v11),
+        .iOS(.v12),
         .macOS(.v10_14),
         .tvOS(.v13),
-        .watchOS(.v8)
+        .watchOS(.v8),
+        .visionOS(.v1)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.


### PR DESCRIPTION
I bumped swift-tool-version to 5.9. And adding `.visionOS(.v1)` to Package.swift. Incidentally, as `.iOS(.v11)` was deprecated, I fixed it to `iOS(.v12)`.

https://developer.apple.com/documentation/packagedescription/supportedplatform/iosversion/v11