### PR TITLE
Disable emitted module interface verification in order to create an XCFramework

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,9 @@
 
 import PackageDescription
 
+let swiftSettings: [SwiftSetting]
+swiftSettings = [.unsafeFlags(["-no-verify-emitted-module-interface"], .when(configuration: .release))]
+
 let package = Package(
     name: "Factory",
     platforms: [
@@ -28,7 +31,8 @@ let package = Package(
         .target(
             name: "Factory",
             dependencies: [],
-            resources: [.copy("PrivacyInfo.xcprivacy")]),
+            resources: [.copy("PrivacyInfo.xcprivacy")],
+            swiftSettings: swiftSettings),
         .testTarget(
             name: "FactoryTests",
             dependencies: ["Factory"]),


### PR DESCRIPTION
Hello!

As you mentioned in [issue#173](https://github.com/hmlongco/Factory/issues/173) making Key internal solved the issue with the compiler

However, the issue with xcodebuild failing to create an XCFramework remained. As for now, trying to create XCFramework using latest `Factory 2.3.2` outputs a `SwiftVerifyEmittedModuleInterface` error

As I searched through, module verification was added starting from Xcode 14.3 and the only workaround I could find was to add a flag to disable it