### PR TITLE
Fix Swift 6 compatibility

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,5 +32,8 @@ let package = Package(
         .testTarget(
             name: "FactoryTests",
             dependencies: ["Factory"]),
+    ],
+    swiftLanguageVersions: [
+      .v5
     ]
 )

--- a/Sources/Factory/Factory/Containers.swift
+++ b/Sources/Factory/Factory/Containers.swift
@@ -42,8 +42,13 @@ import Foundation
 ///
 ///  See <doc:Containers> for more information.
 public final class Container: SharedContainer {
+    #if compiler(>=6.0)
+    /// Define the default shared container.
+    public nonisolated(unsafe) static let shared = Container()
+    #else
     /// Define the default shared container.
     public static let shared = Container()
+    #endif
     /// Define the container's manager.
     public let manager: ContainerManager = ContainerManager()
     /// Public initializer

--- a/Sources/Factory/Factory/Scopes.swift
+++ b/Sources/Factory/Factory/Scopes.swift
@@ -123,8 +123,13 @@ extension Scope {
         internal var cache = Cache()
     }
 
+    #if compiler(>=6.0)
+    /// A reference to the default shared scope manager.
+    public nonisolated(unsafe) static let shared = Shared()
+    #else
     /// A reference to the default shared scope manager.
     public static let shared = Shared()
+    #endif
     /// Defines a shared (weak) scope. The same instance will be returned by the factory as long as someone maintains a strong reference.
     public final class Shared: Scope {
         public override init() {
@@ -156,8 +161,13 @@ extension Scope {
         }
     }
 
+    #if compiler(>=6.0)
+    /// A reference to the default singleton scope manager.
+    public nonisolated(unsafe) static let singleton = Singleton()
+    #else
     /// A reference to the default singleton scope manager.
     public static let singleton = Singleton()
+    #endif
     /// Defines the singleton scope. The same instance will always be returned by the factory.
     public final class Singleton: Scope, InternalScopeCaching {
         public override init() {
@@ -177,10 +187,18 @@ extension Scope {
         }
     }
 
+    #if compiler(>=6.0)
+    /// A reference to the default unique scope.
+    ///
+    /// If no scope cache is specified then Factory is running in unique more.
+    public nonisolated(unsafe) static let unique = Unique()
+    #else
     /// A reference to the default unique scope.
     ///
     /// If no scope cache is specified then Factory is running in unique more.
     public static let unique = Unique()
+    #endif
+
     /// Defines the unique scope. A new instance of a given type will be returned on every resolution cycle.
     public final class Unique: Scope {
         public override init() {


### PR DESCRIPTION
See #190.

`Factory` is not compatible with Swift 6, so this makes that explicit. Without this, apps compiling against `Factory` when using Swift 6 will try to compile it with that and fail.