### PR TITLE
[Swift 6] `Sendable` conformance to allow defining actor-isolated `Factory`s

### DIFF
--- a/Sources/Factory/Factory/Containers.swift
+++ b/Sources/Factory/Factory/Containers.swift
@@ -98,11 +98,11 @@ public protocol ManagedContainer: AnyObject, Sendable {
 /// Defines the default factory helpers for containers
 extension ManagedContainer {
     /// Syntactic sugar allows container to create a properly bound Factory.
-    @inlinable @inline(__always) public func callAsFunction<T>(key: StaticString = #function, _ factory: @escaping () -> T) -> Factory<T> {
+    @inlinable @inline(__always) public func callAsFunction<T>(key: StaticString = #function, _ factory: @escaping @Sendable () -> T) -> Factory<T> {
         Factory(self, key: key, factory)
     }
     /// Syntactic sugar allows container to create a properly bound ParameterFactory.
-    @inlinable @inline(__always) public func callAsFunction<P,T>(key: StaticString = #function, _ factory: @escaping (P) -> T) -> ParameterFactory<P,T> {
+    @inlinable @inline(__always) public func callAsFunction<P,T>(key: StaticString = #function, _ factory: @escaping @Sendable (P) -> T) -> ParameterFactory<P,T> {
         ParameterFactory(self, key: key, factory)
     }
     /// Syntactic sugar allows container to create a factory whose optional registration is promised before resolution.

--- a/Sources/Factory/Factory/Factory.swift
+++ b/Sources/Factory/Factory/Factory.swift
@@ -72,7 +72,7 @@ public struct Factory<T>: FactoryModifying {
     ///   current container as well defining the scope.
     ///   - key: Hidden value used to differentiate different instances of the same type in the same container.
     ///   - factory: A factory closure that produces an object of the desired type when required.
-    public init(_ container: ManagedContainer, key: StaticString = #function, _ factory: @escaping () -> T) {
+    public init(_ container: ManagedContainer, key: StaticString = #function, _ factory: @escaping @Sendable () -> T) {
         self.registration = FactoryRegistration<Void,T>(key: key, container: container, factory: factory)
     }
 
@@ -133,7 +133,7 @@ public struct Factory<T>: FactoryModifying {
     ///  - factory: A new factory closure that produces an object of the desired type when needed.
     /// Allows updating registered factory and scope.
     @discardableResult
-    public func register(factory: @escaping () -> T) -> Self {
+    public func register(factory: @escaping @Sendable () -> T) -> Self {
         registration.register(factory)
         return self
     }
@@ -143,6 +143,8 @@ public struct Factory<T>: FactoryModifying {
     public var registration: FactoryRegistration<Void,T>
 
 }
+
+extension Factory: Sendable where T: Sendable {}
 
 // MARK: - ParameterFactory
 
@@ -198,7 +200,7 @@ public struct ParameterFactory<P,T>: FactoryModifying {
     ///   current container as well defining the scope.
     ///   - key: Hidden value used to differentiate different instances of the same type in the same container.
     ///   - factory: A factory closure that produces an object of the desired type when required.
-    public init(_ container: ManagedContainer, key: StaticString = #function, _ factory: @escaping (P) -> T) {
+    public init(_ container: ManagedContainer, key: StaticString = #function, _ factory: @escaping @Sendable (P) -> T) {
         self.registration = FactoryRegistration<P,T>(key: key, container: container, factory: factory)
     }
 
@@ -224,7 +226,7 @@ public struct ParameterFactory<P,T>: FactoryModifying {
     /// - Parameters:
     ///  - factory: A new factory closure that produces an object of the desired type when needed.
     @discardableResult
-    public func register(factory: @escaping (P) -> T) -> Self {
+    public func register(factory: @escaping @Sendable (P) -> T) -> Self {
         registration.register(factory)
         return self
     }

--- a/Sources/Factory/Factory/Modifiers.swift
+++ b/Sources/Factory/Factory/Modifiers.swift
@@ -148,7 +148,7 @@ extension FactoryModifying {
     /// ```
     /// As shown, decorator can come in handy when you need to perform some operation or manipulation after the fact.
     @discardableResult
-    public func decorator(_ decorator: @escaping (_ instance: T) -> Void) -> Self {
+    public func decorator(_ decorator: @escaping @Sendable (_ instance: T) -> Void) -> Self {
         registration.decorator(decorator)
         return self
     }
@@ -165,7 +165,7 @@ extension FactoryModifying {
     ///
     /// See <doc:Contexts>
     @discardableResult
-    public func context(_ contexts: FactoryContextType..., factory: @escaping (P) -> T) -> Self {
+    public func context(_ contexts: FactoryContextType..., factory: @escaping @Sendable (P) -> T) -> Self {
         for context in contexts {
             switch context {
             case .arg, .args, .device, .simulator:
@@ -182,43 +182,43 @@ extension FactoryModifying {
 
     /// Factory builder shortcut for context(.arg("test") { .. }
     @discardableResult
-    public func onArg(_ argument: String, factory: @escaping (P) -> T) -> Self {
+    public func onArg(_ argument: String, factory: @escaping @Sendable (P) -> T) -> Self {
         context(.arg(argument), factory: factory)
     }
 
     /// Factory builder shortcut for context(.args["test1","test2") { .. }
     @discardableResult
-    public func onArgs(_ args: [String], factory: @escaping (P) -> T) -> Self {
+    public func onArgs(_ args: [String], factory: @escaping @Sendable (P) -> T) -> Self {
         context(.args(args), factory: factory)
     }
 
     /// Factory builder shortcut for context(.preview) { .. }
     @discardableResult
-    public func onPreview(factory: @escaping (P) -> T) -> Self {
+    public func onPreview(factory: @escaping @Sendable (P) -> T) -> Self {
         context(.preview, factory: factory)
     }
 
     /// Factory builder shortcut for context(.test) { .. }
     @discardableResult
-    public func onTest(factory: @escaping (P) -> T) -> Self {
+    public func onTest(factory: @escaping @Sendable (P) -> T) -> Self {
         context(.test, factory: factory)
     }
 
     /// Factory builder shortcut for context(.debug) { .. }
     @discardableResult
-    public func onDebug(factory: @escaping (P) -> T) -> Self {
+    public func onDebug(factory: @escaping @Sendable (P) -> T) -> Self {
         context(.debug, factory: factory)
     }
 
     /// Factory builder shortcut for context(.simulator) { .. }
     @discardableResult
-    public func onSimulator(factory: @escaping (P) -> T) -> Self {
+    public func onSimulator(factory: @escaping @Sendable (P) -> T) -> Self {
         context(.simulator, factory: factory)
     }
 
     /// Factory builder shortcut for context(.device) { .. }
     @discardableResult
-    public func onDevice(factory: @escaping (P) -> T) -> Self {
+    public func onDevice(factory: @escaping @Sendable (P) -> T) -> Self {
         context(.device, factory: factory)
     }
 

--- a/Sources/Factory/Factory/Registrations.swift
+++ b/Sources/Factory/Factory/Registrations.swift
@@ -27,14 +27,14 @@
 import Foundation
 
 /// Shared registration type for Factory and ParameterFactory. Used internally to manage the registration and resolution process.
-public struct FactoryRegistration<P,T> {
+public struct FactoryRegistration<P,T>: Sendable {
 
     /// Key used to manage registrations and cached values.
     internal let key: FactoryKey
     /// A strong reference to the container supporting this Factory.
     internal let container: ManagedContainer
     /// Typed factory with scope and factory.
-    internal let factory: (P) -> T
+    internal let factory: @Sendable (P) -> T
 
     #if DEBUG
     /// Internal debug
@@ -45,7 +45,7 @@ public struct FactoryRegistration<P,T> {
     internal var once: Bool = false
 
     /// Initializer for registration sets passed values and default scope from container manager.
-    internal init(key: StaticString, container: ManagedContainer, factory: @escaping (P) -> T) {
+    internal init(key: StaticString, container: ManagedContainer, factory: @escaping @Sendable (P) -> T) {
         self.key = FactoryKey(type: T.self, key: key)
         self.container = container
         self.factory = factory
@@ -157,7 +157,7 @@ public struct FactoryRegistration<P,T> {
     /// - Parameters:
     ///   - id: ID of associated Factory.
     ///   - factory: Factory closure called to create a new instance of the service when needed.
-    internal func register(_ factory: @escaping (P) -> T) {
+    internal func register(_ factory: @escaping @Sendable (P) -> T) {
         defer { globalRecursiveLock.unlock()  }
         globalRecursiveLock.lock()
         container.unsafeCheckAutoRegistration()
@@ -190,7 +190,7 @@ public struct FactoryRegistration<P,T> {
     }
 
     /// Registers a new context.
-    internal func context(_ context: FactoryContextType, key: FactoryKey, factory: @escaping (P) -> T) {
+    internal func context(_ context: FactoryContextType, key: FactoryKey, factory: @escaping @Sendable (P) -> T) {
         options { options in
             switch context {
             case .arg(let arg):
@@ -373,5 +373,5 @@ internal struct FactoryDebugInformation {
 internal protocol AnyFactory {}
 
 internal struct TypedFactory<P,T>: AnyFactory {
-    let factory: (P) -> T
+    let factory: @Sendable (P) -> T
 }

--- a/Sources/Factory/Factory/Resolver.swift
+++ b/Sources/Factory/Factory/Resolver.swift
@@ -32,7 +32,7 @@ import Foundation
 public protocol Resolving: ManagedContainer {
 
     /// Registers a new type and associated factory closure with this container.
-    func register<T>(_ type: T.Type, factory: @escaping () -> T) -> Factory<T>
+    func register<T>(_ type: T.Type, factory: @escaping @Sendable () -> T) -> Factory<T>
 
     /// Returns a registered factory for this type from this container.
     func factory<T>(_ type: T.Type) -> Factory<T>?
@@ -48,7 +48,7 @@ extension Resolving {
     ///
     /// Also returns Factory for further specialization for scopes, decorators, etc.
     @discardableResult
-    public func register<T>(_ type: T.Type = T.self, factory: @escaping () -> T) -> Factory<T> {
+    public func register<T>(_ type: T.Type = T.self, factory: @escaping @Sendable () -> T) -> Factory<T> {
         defer { globalRecursiveLock.unlock() }
         globalRecursiveLock.lock()
         // Perform autoRegistration check

--- a/Tests/FactoryTests/FactoryIsolationTests.swift
+++ b/Tests/FactoryTests/FactoryIsolationTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import Factory
+
+private struct SomeSendableType: Sendable {}
+
+extension Container {
+  @MainActor
+  fileprivate var instance: Factory<SomeSendableType> {
+    self { .init() }
+  }
+}
+
+final class FactoryIsolationTests: XCTestCase {
+
+  override func setUp() {
+    super.setUp()
+    Container.shared.reset()
+  }
+
+  func testInjectMainActorDependency() async {
+    let _: SomeSendableType = await Container.shared.instance()
+  }
+
+}


### PR DESCRIPTION
Fixes #215

This allows doing this:
```swift
private struct SomeSendableType: Sendable {}

extension Container {
  @MainActor
  var instance: Factory<SomeSendableType> {
    self { .init() }
  }
}
```