### PR TITLE
[Swift 6] `MainActorFactory`

### DIFF
--- a/Sources/Factory/Factory/MainActorFactory.swift
+++ b/Sources/Factory/Factory/MainActorFactory.swift
@@ -1,0 +1,35 @@
+public protocol MainActorInitiazable<Value>: Sendable {
+  associatedtype Value
+
+  var factory: @MainActor () -> Value { get }
+}
+
+public struct MainActorWrapper<Value>: MainActorInitiazable, Sendable {
+  public let factory: @MainActor () -> Value
+
+  public init(factory: @escaping @MainActor () -> Value) {
+    self.factory = factory
+  }
+}
+
+public typealias MainActorFactory<Value> = Factory<MainActorWrapper<Value>>
+
+extension ManagedContainer {
+  @inlinable @inline(__always) public func callAsFunction<T>(
+    key: StaticString = #function,
+    _ factory: @escaping @MainActor () -> T
+  ) -> MainActorFactory<T> {
+    .init(self, key: key) {
+      MainActorWrapper {
+        factory()
+      }
+    }
+  }
+}
+
+extension Factory where T: MainActorInitiazable {
+  @MainActor
+  public func resolve() -> T.Value {
+    callAsFunction().factory()
+  }
+}

--- a/Tests/FactoryTests/FactoryIsolationTests.swift
+++ b/Tests/FactoryTests/FactoryIsolationTests.swift
@@ -3,10 +3,6 @@ import XCTest
 
 private struct SomeSendableType: Sendable {}
 
-private struct AsyncInitWrapper<T>: Sendable {
-  let wrapped: @Sendable () async -> T
-}
-
 @MainActor
 private final class SomeMainActorType: Sendable {
   init() {}
@@ -17,12 +13,9 @@ extension Container {
     self { .init() }
   }
 
-  @MainActor
-  fileprivate var mainActor: Factory<AsyncInitWrapper<SomeMainActorType>> {
+  fileprivate var mainActor: MainActorFactory<SomeMainActorType> {
     self {
-      .init {
-        await SomeMainActorType()
-      }
+      SomeMainActorType()
     }
   }
 }
@@ -39,7 +32,7 @@ final class FactoryIsolationTests: XCTestCase {
   }
 
   func testInjectMainActorDependency() async {
-    let _: SomeMainActorType = await Container.shared.mainActor().wrapped()
+    let _: SomeMainActorType = await Container.shared.mainActor().factory()
   }
 
 }


### PR DESCRIPTION
Follow up to #218 with a proposal for how to provide dependencies that are `@MainActor`.