### PR TITLE
Add @DynamicInjected property wrapper

### DIFF
--- a/Sources/Factory/Factory.docc/Additional/Migration.md
+++ b/Sources/Factory/Factory.docc/Additional/Migration.md
@@ -97,7 +97,7 @@ Finally, you can also use the @Injected property wrapper. That's changed too, an
 ```
 The @Injected property wrapper looks for dependencies in the shared container, so this example is functionally identical to the `Container.shared.service()` version shown above.
 
-See ``Injected``, ``LazyInjected``, ``WeakLazyInjected``, and ``InjectedObject`` for more.
+See ``Injected``, ``LazyInjected``, ``WeakLazyInjected``, ``DynamicInjected`` and ``InjectedObject`` for more.
 
 ```swift
 // Factory 1.0 version for reference

--- a/Sources/Factory/Factory.docc/Advanced/Design.md
+++ b/Sources/Factory/Factory.docc/Advanced/Design.md
@@ -146,7 +146,7 @@ class ContentViewModel: ObservableObject {
 ```
 Factory 2.0 also updates the syntax to use keyPaths, much like SwiftUI environment variables.
 
-See ``Injected``, ``LazyInjected``, ``WeakLazyInjected``, and ``InjectedObject`` for more.
+See ``Injected``, ``LazyInjected``, ``WeakLazyInjected``, ``DynamicInjected`` and ``InjectedObject`` for more.
 
 ## Breaking Changes
 

--- a/Sources/Factory/Factory.docc/Basics/Containers.md
+++ b/Sources/Factory/Factory.docc/Basics/Containers.md
@@ -136,7 +136,7 @@ class ContentViewModel: ObservableObject {
 ```
 We now have an instance of `cachedService` in our view model, as well as a reference to the same instance cached in `MyContainer.shared.manager`.
 
-See ``Injected``, ``LazyInjected``, ``WeakLazyInjected``, and ``InjectedObject`` for more.
+See ``Injected``, ``LazyInjected``, ``WeakLazyInjected``, ``DynamicInjected`` and ``InjectedObject`` for more.
 
 ## Registration and Scope Management
 

--- a/Sources/Factory/Factory.docc/Basics/Resolutions.md
+++ b/Sources/Factory/Factory.docc/Basics/Resolutions.md
@@ -69,7 +69,7 @@ struct ContentView: View {
     }
 }
 ```
-See ``Injected``, ``LazyInjected``, ``WeakLazyInjected``, and ``InjectedObject`` for more.
+See ``Injected``, ``LazyInjected``, ``WeakLazyInjected``, ``DynamicInjected`` and ``InjectedObject`` for more.
 
 ### Global Keypath Resolution from Shared Container
 Factory provides two global functions that utilize keypaths for resolution. 

--- a/Tests/FactoryTests/FactoryInjectionTests.swift
+++ b/Tests/FactoryTests/FactoryInjectionTests.swift
@@ -27,6 +27,13 @@ class Services3 {
     init() {}
 }
 
+class Services4 {
+    @DynamicInjected(\.myServiceType) var service
+    @DynamicInjected(\.mockService) var mock
+    @DynamicInjected(\CustomContainer.test) var test
+    init() {}
+}
+
 class Services5 {
     @Injected(\.optionalService) var service
     init() {}
@@ -55,6 +62,7 @@ extension Container {
     fileprivate var services1: Factory<Services1> { self { Services1() } }
     fileprivate var services2: Factory<Services2> { self { Services2() } }
     fileprivate var services3: Factory<Services3> { self { Services3() } }
+    fileprivate var services4: Factory<Services4> { self { Services4() } }
     fileprivate var servicesP: Factory<ServicesP> { self { ServicesP() }.shared }
     fileprivate var servicesC: Factory<ServicesC> { self { ServicesC() }.shared }
 }
@@ -123,6 +131,13 @@ final class FactoryInjectionTests: XCTestCase {
         XCTAssertEqual(services.mock.text(), "MockService")
         XCTAssertEqual(services.test.text(), "MockService32")
         XCTAssertNotNil(services.$service.resolvedOrNil())
+    }
+    
+    func testDynamicInjection() throws {
+        let services = Services4()
+        XCTAssertEqual(services.service.text(), "MyService")
+        XCTAssertEqual(services.mock.text(), "MockService")
+        XCTAssertEqual(services.test.text(), "MockService32")
     }
 
     func testLazyInjectionOccursOnce() throws {
@@ -232,6 +247,14 @@ final class FactoryInjectionTests: XCTestCase {
         service.$service.resolve()
 
         XCTAssertNil(service.service)
+    }
+    
+    func testDynamicInjectionResolve() throws {
+        let object = Container.shared.services4()
+        let oldId = object.service.id
+        // should have new instance
+        let newId = object.service.id
+        XCTAssertTrue(oldId != newId)
     }
 
     #if canImport(SwiftUI)


### PR DESCRIPTION
Adds the `@DynamicInjected` property wrapper. Unlike the other property wrappers the resolved instance through the factory is not held in a stored property. This can be useful for one-shot operations where a dependency is used only in the scope of one function and then no longer needed.

### Example

```swift
class MyApplication {
    @DynamicInjected(\.myService) var myService

    func doSomethingOnce() async throws {
        let result = try await myService.checkSomething()
        […]
    }

    […]
}
```

Here we don't want to keep a reference to `myService` because it's only needed once and we want it to deinit afterwards.

### Alternatives

#### Computed property
Using a computed property achieves the same behavior. But the property wrapper is nicer.

```swift
class MyApplication {
    var myService: MyService {
        SharedContainer.shared.myService()
    }
}
```

### Declaration

The program was tested solely for our own use cases, which might differ from yours.

### Link to provider information

https://github.com/mercedes-benz