### PR TITLE
Allow MainActor Dependency Registration

### DIFF
--- a/Sources/Factory/Factory/Containers.swift
+++ b/Sources/Factory/Factory/Containers.swift
@@ -105,6 +105,17 @@ extension ManagedContainer {
     @inlinable @inline(__always) public func callAsFunction<P,T>(key: StaticString = #function, _ factory: @escaping @Sendable (P) -> T) -> ParameterFactory<P,T> {
         ParameterFactory(self, key: key, factory)
     }
+    
+    @MainActor
+    @inlinable @inline(__always) public func register<T>(key: StaticString = #function, _ factory: @escaping @MainActor () -> T) -> Factory<T> {
+        return Factory(self, key: key, factory)
+    }
+    
+    @MainActor
+    @inlinable @inline(__always) public func register<P,T>(key: StaticString = #function, _ factory: @escaping @MainActor (P) -> T) -> ParameterFactory<P,T> {
+        return ParameterFactory(self, key: key, factory)
+    }
+    
     /// Syntactic sugar allows container to create a factory whose optional registration is promised before resolution.
     /// ```swift
     /// extension Container {

--- a/Sources/Factory/Factory/Containers.swift
+++ b/Sources/Factory/Factory/Containers.swift
@@ -106,13 +106,15 @@ extension ManagedContainer {
         ParameterFactory(self, key: key, factory)
     }
     
+    /// Syntactic sugar allows container to create a properly bound Factory on MainActor.
     @MainActor
-    @inlinable @inline(__always) public func register<T>(key: StaticString = #function, _ factory: @escaping @MainActor () -> T) -> Factory<T> {
+    @inlinable @inline(__always) public func callAsFunction<T: Sendable>(key: StaticString = #function, _ factory: @escaping @MainActor () -> T) -> Factory<T> {
         return Factory(self, key: key, factory)
     }
     
+    /// Syntactic sugar allows container to create a properly bound ParameterFactory on MainActor.
     @MainActor
-    @inlinable @inline(__always) public func register<P,T>(key: StaticString = #function, _ factory: @escaping @MainActor (P) -> T) -> ParameterFactory<P,T> {
+    @inlinable @inline(__always) public func callAsFunction<P,T: Sendable>(key: StaticString = #function, _ factory: @escaping @MainActor (P) -> T) -> ParameterFactory<P,T> {
         return ParameterFactory(self, key: key, factory)
     }
     

--- a/Sources/Factory/Factory/Factory.swift
+++ b/Sources/Factory/Factory/Factory.swift
@@ -72,7 +72,7 @@ public struct Factory<T>: FactoryModifying {
     ///   current container as well defining the scope.
     ///   - key: Hidden value used to differentiate different instances of the same type in the same container.
     ///   - factory: A factory closure that produces an object of the desired type when required.
-    public init(_ container: ManagedContainer, key: StaticString = #function, _ factory: @escaping @Sendable () -> T) {
+    public init(_ container: ManagedContainer, key: StaticString = #function, _ factory: @escaping () -> T) {
         self.registration = FactoryRegistration<Void,T>(key: key, container: container, factory: factory)
     }
 
@@ -144,8 +144,6 @@ public struct Factory<T>: FactoryModifying {
 
 }
 
-extension Factory: Sendable where T: Sendable {}
-
 // MARK: - ParameterFactory
 
 /// Factory capable of taking parameters at runtime
@@ -200,7 +198,7 @@ public struct ParameterFactory<P,T>: FactoryModifying {
     ///   current container as well defining the scope.
     ///   - key: Hidden value used to differentiate different instances of the same type in the same container.
     ///   - factory: A factory closure that produces an object of the desired type when required.
-    public init(_ container: ManagedContainer, key: StaticString = #function, _ factory: @escaping @Sendable (P) -> T) {
+    public init(_ container: ManagedContainer, key: StaticString = #function, _ factory: @escaping (P) -> T) {
         self.registration = FactoryRegistration<P,T>(key: key, container: container, factory: factory)
     }
 

--- a/Sources/Factory/Factory/Globals.swift
+++ b/Sources/Factory/Factory/Globals.swift
@@ -32,7 +32,7 @@ import Foundation
 nonisolated(unsafe) internal var globalGraphResolutionDepth = 0
 
 /// Internal key used for Resolver mode
-nonisolated(unsafe) internal let globalResolverKey: StaticString = "*"
+internal let globalResolverKey: StaticString = "*"
 
 #if DEBUG
 /// Internal variables used for debugging

--- a/Sources/Factory/Factory/Registrations.swift
+++ b/Sources/Factory/Factory/Registrations.swift
@@ -27,14 +27,14 @@
 import Foundation
 
 /// Shared registration type for Factory and ParameterFactory. Used internally to manage the registration and resolution process.
-public struct FactoryRegistration<P,T>: Sendable {
+public struct FactoryRegistration<P,T> {
 
     /// Key used to manage registrations and cached values.
     internal let key: FactoryKey
     /// A strong reference to the container supporting this Factory.
     internal let container: ManagedContainer
     /// Typed factory with scope and factory.
-    internal let factory: @Sendable (P) -> T
+    internal let factory: (P) -> T
 
     #if DEBUG
     /// Internal debug
@@ -45,7 +45,7 @@ public struct FactoryRegistration<P,T>: Sendable {
     internal var once: Bool = false
 
     /// Initializer for registration sets passed values and default scope from container manager.
-    internal init(key: StaticString, container: ManagedContainer, factory: @escaping @Sendable (P) -> T) {
+    internal init(key: StaticString, container: ManagedContainer, factory: @escaping (P) -> T) {
         self.key = FactoryKey(type: T.self, key: key)
         self.container = container
         self.factory = factory

--- a/Tests/FactoryTests/FactoryIsolationTests.swift
+++ b/Tests/FactoryTests/FactoryIsolationTests.swift
@@ -37,7 +37,8 @@ final class FactoryIsolationTests: XCTestCase {
   func testInjectSendableDependency() {
     let _: SomeSendableType = Container.shared.sendable()
   }
-
+    
+  @MainActor
   func testInjectMainActorDependency() async {
     let _: SomeMainActorType = await Container.shared.mainActor().wrapped()
   }

--- a/Tests/FactoryTests/MockServices.swift
+++ b/Tests/FactoryTests/MockServices.swift
@@ -9,7 +9,7 @@ import Foundation
 @testable import Factory
 
 // Swift 6
-extension Container: @retroactive AutoRegistering {
+extension Container: AutoRegistering {
     public func autoRegister() {
         // print("Container.autoRegister")
     }


### PR DESCRIPTION
### What this does?

I have been reading through all of the issues related to MainActor isolation / MainActor resolution on Factory and there were some clear concerns that this is not the concern of Factory, while I kind of agree but I think Factory should be able to adapt to different approaches, whether you choose to either conform your entire ViewModel to @.MainActor or mark only certain functions, as long as you provide the correct definitions of your dependency registration / resolution, things should just work

### How was this achieved?

* Sendable requirement was relaxed in Factory / ParameterFactory / FactoryRegistration
* But the registration on Container still enforces this Sendability
* Introduce two new functions that are MainActor specific for registering dependencies that are MainActor isolated

Using these two functions we are allowed to do such declaration which isolates our dependency registration to the scope that they are defined on, in our case MainActor

<img width="572" alt="Screenshot 2024-09-04 at 22 02 56" src="https://github.com/user-attachments/assets/dd172dae-9a0d-442f-873f-74cda95a50a6">

And now it's on the compiler to ensure that you are actually resolving MainActor dependencies only from MainActor bound classes, but you also may use non-MainActor bound classes in MainActor classes.

Example:

```
@MainActor
final class NotificationsViewModel: ViewModel {
    // MARK: DI
    @Injected(\.deepLinkHandlerViewModel) private var deepLinkHandlerViewModel // This is MainActor isolated and compiles
    @Injected(\.deepLinkGenerator) private var deepLinkGenerator // This is not MainActor and also compiles and the resolution works as expected
```

But if we were to remove @.MainActor annotation from this ViewModel, this would result into the following warning (soon to be error)

<img width="1231" alt="Screenshot 2024-09-04 at 22 10 38" src="https://github.com/user-attachments/assets/09333f60-941d-465c-93ac-94233a1eaeaf">

Which means that we have achieved even more compile-safety when defining / resolving dependencies.

Let me know what do you think