### PR TITLE
[Swift 6] Restore Swift 5 compatibility

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -42,17 +42,14 @@ let package = Package(
         .target(
             name: "Factory",
             dependencies: [],
-            resources: [.copy("PrivacyInfo.xcprivacy")],
-            swiftSettings: [
-                .swiftLanguageMode(.v6)
-            ]
+            resources: [.copy("PrivacyInfo.xcprivacy")]
         ),
         .testTarget(
             name: "FactoryTests",
-            dependencies: ["Factory"],
-            swiftSettings: [
-                .swiftLanguageMode(.v6)
-            ]
-        ),
+            dependencies: ["Factory"]
+        )
+    ],
+    swiftLanguageVersions: [
+        .v5, .version("6.0")
     ]
 )


### PR DESCRIPTION
3ca72ff changed `Package.swift` to only be compatible with `Swift 6`. This led to the following error when using `Factory` from `Xcode 15`:
>  package 'factory' is using Swift tools version 6.0.0 but the installed version is 5.10.0 in https://github.com/hmlongco/Factory.git