### PR TITLE
[Swift 6] use isolated(any) for factory closures

### DIFF
--- a/Sources/Factory/Factory/Containers.swift
+++ b/Sources/Factory/Factory/Containers.swift
@@ -98,11 +98,11 @@ public protocol ManagedContainer: AnyObject, Sendable {
 /// Defines the default factory helpers for containers
 extension ManagedContainer {
     /// Syntactic sugar allows container to create a properly bound Factory.
-    @inlinable @inline(__always) public func callAsFunction<T>(key: StaticString = #function, _ factory: @escaping @Sendable () -> T) -> Factory<T> {
+    @inlinable @inline(__always) public func callAsFunction<T>(key: StaticString = #function, _ factory: @escaping @Sendable @isolated(any) () -> T) -> Factory<T> {
         Factory(self, key: key, factory)
     }
     /// Syntactic sugar allows container to create a properly bound ParameterFactory.
-    @inlinable @inline(__always) public func callAsFunction<P,T>(key: StaticString = #function, _ factory: @escaping @Sendable (P) -> T) -> ParameterFactory<P,T> {
+    @inlinable @inline(__always) public func callAsFunction<P,T>(key: StaticString = #function, _ factory: @escaping @Sendable @isolated(any) (P) -> T) -> ParameterFactory<P,T> {
         ParameterFactory(self, key: key, factory)
     }
     /// Syntactic sugar allows container to create a factory whose optional registration is promised before resolution.

--- a/Sources/Factory/Factory/Factory.swift
+++ b/Sources/Factory/Factory/Factory.swift
@@ -72,7 +72,7 @@ public struct Factory<T>: FactoryModifying {
     ///   current container as well defining the scope.
     ///   - key: Hidden value used to differentiate different instances of the same type in the same container.
     ///   - factory: A factory closure that produces an object of the desired type when required.
-    public init(_ container: ManagedContainer, key: StaticString = #function, _ factory: @escaping @Sendable () -> T) {
+    public init(_ container: ManagedContainer, key: StaticString = #function, _ factory: @escaping @Sendable @isolated(any) () -> T) {
         self.registration = FactoryRegistration<Void,T>(key: key, container: container, factory: factory)
     }
 
@@ -133,7 +133,7 @@ public struct Factory<T>: FactoryModifying {
     ///  - factory: A new factory closure that produces an object of the desired type when needed.
     /// Allows updating registered factory and scope.
     @discardableResult
-    public func register(factory: @escaping @Sendable () -> T) -> Self {
+    public func register(factory: @escaping @Sendable @isolated(any) () -> T) -> Self {
         registration.register(factory)
         return self
     }
@@ -200,7 +200,7 @@ public struct ParameterFactory<P,T>: FactoryModifying {
     ///   current container as well defining the scope.
     ///   - key: Hidden value used to differentiate different instances of the same type in the same container.
     ///   - factory: A factory closure that produces an object of the desired type when required.
-    public init(_ container: ManagedContainer, key: StaticString = #function, _ factory: @escaping @Sendable (P) -> T) {
+    public init(_ container: ManagedContainer, key: StaticString = #function, _ factory: @escaping @Sendable @isolated(any) (P) -> T) {
         self.registration = FactoryRegistration<P,T>(key: key, container: container, factory: factory)
     }
 
@@ -226,7 +226,7 @@ public struct ParameterFactory<P,T>: FactoryModifying {
     /// - Parameters:
     ///  - factory: A new factory closure that produces an object of the desired type when needed.
     @discardableResult
-    public func register(factory: @escaping @Sendable (P) -> T) -> Self {
+    public func register(factory: @escaping @Sendable @isolated(any) (P) -> T) -> Self {
         registration.register(factory)
         return self
     }

--- a/Tests/FactoryTests/FactoryIsolationTests.swift
+++ b/Tests/FactoryTests/FactoryIsolationTests.swift
@@ -4,42 +4,164 @@ import XCTest
 private struct SomeSendableType: Sendable {}
 
 private struct AsyncInitWrapper<T>: Sendable {
-  let wrapped: @Sendable () async -> T
+    let wrapped: @Sendable () async -> T
 }
 
-@MainActor
-private final class SomeMainActorType: Sendable {
-  init() {}
+@MainActor private final class SomeMainActorType: Sendable {
+    init() {}
+}
+
+private actor SomeActor {
+    var value: Int = 0
+    
+    init() {}
+    
+    func increment() {
+        value += 1
+    }
+}
+
+@MainActor private final class ImplicitlySendableMainActorType {
+    init() {}
+}
+
+@globalActor
+public actor GlobalActor {
+    public typealias ActorType = GlobalActor
+
+    public static let shared = ActorType()
+}
+
+@GlobalActor private final class ImplicitlySendableGlobalActorType {
+    init() {}
 }
 
 extension Container {
-  fileprivate var sendable: Factory<SomeSendableType> {
-    self { .init() }
-  }
-
-  @MainActor
-  fileprivate var mainActor: Factory<AsyncInitWrapper<SomeMainActorType>> {
-    self {
-      .init {
-        await SomeMainActorType()
-      }
+    fileprivate var sendable: Factory<SomeSendableType> {
+        self { .init() }
     }
-  }
+
+    @MainActor fileprivate var mainActor: Factory<AsyncInitWrapper<SomeMainActorType>> {
+        self {
+            .init {
+                await SomeMainActorType()
+            }
+        }
+    }
+    
+    fileprivate var someActor: Factory<SomeActor> {
+        self { .init() }
+    }
+    
+    @MainActor fileprivate var implicitlySendableMainActor: Factory<ImplicitlySendableMainActorType> {
+        self { @MainActor in .init() }
+    }
+    
+    fileprivate var nonisolatedImplicitlySendableMainActor: Factory<ImplicitlySendableMainActorType> {
+        self { @MainActor in .init() }
+    }
+    
+    @GlobalActor fileprivate var globalActor: Factory<ImplicitlySendableGlobalActorType> {
+        Factory(self) { @GlobalActor in .init() }
+    }
 }
 
 final class FactoryIsolationTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        Container.shared.reset()
+    }
 
-  override func setUp() {
-    super.setUp()
-    Container.shared.reset()
-  }
+    func testInjectSendableDependency() {
+        let _: SomeSendableType = Container.shared.sendable()
+    }
 
-  func testInjectSendableDependency() {
-    let _: SomeSendableType = Container.shared.sendable()
-  }
+    func testInjectMainActorDependency() async {
+        let _: SomeMainActorType = await Container.shared.mainActor().wrapped()
+    }
+    
+    func testSomeActorDependency() async {
+        let someActor = Container.shared.someActor()
+        
+        await someActor.increment()
+        let value = await someActor.value
+        
+        XCTAssertEqual(value, 1)
+    }
+    
+    @MainActor func testImplicitlySendableMainActorDependency() async {
+        _ = Container.shared.implicitlySendableMainActor()
+    }
+    
+    // Compiler error:
+    // Main actor-isolated property 'implicitlySendableMainActor' can not be referenced from a Sendable closure
+//    @MainActor func testImplicitlySendableMainActorDependencyInBackground() {
+//        DispatchQueue.global().async {
+//            _ = Container.shared.implicitlySendableMainActor()
+//        }
+//    }
+    
+    @MainActor func testImplicitlySendableMainActorDependencyInBackground() async {
+        let exp = expectation(description: "\(#function)")
+        
+        DispatchQueue.global().async {
+            Task { @MainActor in
+                _ = Container.shared.implicitlySendableMainActor()
+                exp.fulfill()
+            }
+        }
+        
+        await fulfillment(of: [exp])
+    }
+    
+    // crash from dispatch_assert_queue
+    // !!!: no compiler warning about this
+//    @MainActor func testImplicitlySendableMainActorDependencyInBackground() {
+//        let exp = expectation(description: "\(#function)")
+//        
+//        DispatchQueue.global().async {
+//            Task {
+//                await _ = Container.shared.implicitlySendableMainActor()
+//                exp.fulfill()
+//            }
+//        }
+//        
+//        wait(for: [exp])
+//    }
+    
+    // works because we are probably implicitly on the main thread
+    func testNonisolatedImplicitlySendableMainActorDependency() {
+        _ = Container.shared.nonisolatedImplicitlySendableMainActor()
+    }
+    
+    // crashes because the test is not started on the MainActor
+//    func testNonisolatedImplicitlySendableMainActorDependency() async {
+//        _ = Container.shared.nonisolatedImplicitlySendableMainActor()
+//    }
+    
+    // crash because runtime check of factory closure is not run on MainActor
+    // !!!: no compiler warning about this
+//    func testNonisolatedImplicitlySendableMainActorDependencyInBackground() {
+//        DispatchQueue.global().async {
+//            _ = Container.shared.nonisolatedImplicitlySendableMainActor()
+//        }
+//    }
+    
+    // crashes on Swift 6 because the test is started on the MainActor and requires the method be async
+//    @GlobalActor func testGlobalActorDependency() {
+//        let a = 1
+//    }
+    
+    @GlobalActor func testGlobalActorDependency() async {
+        _ = Container.shared.globalActor()
+    }
+    
+    func testGetGlobalActor() async {
+        await _ = getGlobalActor()
+    }
+}
 
-  func testInjectMainActorDependency() async {
-    let _: SomeMainActorType = await Container.shared.mainActor().wrapped()
-  }
-
+// contrived global function to force any compiler warnings
+@GlobalActor fileprivate func getGlobalActor() -> ImplicitlySendableGlobalActorType {
+    Container.shared.globalActor()
 }


### PR DESCRIPTION
The `2.4` update added `Sendable` conformance to the factory closures which breaks using GAIT types in `Container` and elsewhere.  For example:

```swift
@DaemonActor
public final class XPCDaemon {
    public static let shared = XPCDaemon()

    public init() {}
}

@MainActor
public final class State {
    public init() {}
}

extension Container {
    @DaemonActor var daemon: Factory<XPCDaemon> {
        Factory(self) { XPCDaemon.shared } // Global actor 'DaemonActor'-isolated class property 'shared' can not be referenced from a Sendable closure
    }

    // also a problem for `MainActor` types
    @MainActor var state: Factory<State> {
        self { .init() } // Converting function value of type '@MainActor @Sendable () -> State' to '@Sendable () -> State' loses global actor 'MainActor'
    }
}
```

By adding `isolated(any)` to the factory closures we can explicitly mark which global actor the closure should be isolated on. The above can now be written without any errors or intermediate wrapper types:

```swift
extension Container {
    @DaemonActor var daemon: Factory<XPCDaemon> {
        Factory(self) { @DaemonActor in XPCDaemon.shared }
    }

    @MainActor var state: Factory<State> {
        self { @MainActor in .init() }
    }
}
```

Some important details to consider. From the [431 evolution proposal](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0431-isolated-any-functions.md) it mentions that functions that use `isolated(any)` are assumed to cross an isolation boundary and are thus implicitly `async` and must be `await`ed. It seems the compiler allows these functions to be assigned to properties where `isolated(any)` is not used and then called without using `await`. Not sure if this is intended or possibly a compiler bug. The proposal also mentions that when the compiler can detect that an isolation region is not crossed then it seems the function wouldn't need to be `await`ed. All of those conditions would be satisfied if the getter in `Container` is using the GAIT (e.g. `@MainActor`) and the factory closure is also using the GAIT. Then if no isolation region is crossed no `await` is needed otherwise an `await` will be required by the compiler.

Currently it's possible to write something like this:

```swift
extension Container {
    // missing `@MainActor` attribute
    var state: Factory<State> {
        self { @MainActor in .init() }
    }
}
```

and then use it like this:

```swift
    @MainActor func doSomething() {
        DispatchQueue.global().async {
            _ = Container.shared.state() // crash here without compiler error because `state()` is `nonisolated`
        }
    }
```

Which causes a quick quit easter egg. The only way I can think of avoiding this situation is if the calls to the factory closure were always `await`ed on which sort of defeats the purpose of having everything assigned to the same global actor. I'm open to ideas if anyone has any clues of how to force the compiler to recognize the isolation context. It would be nice if this worked:

```swift
extension Container {
    @MainActor var state: Factory<State> {
        // `isolated(any)` picks up `@MainActor` from property definition, which would require using the `@MainActor` attribute for the property definition
        self { .init() }
    }
}
```

From the 431 proposal:

> A function value with this type dynamically carries the isolation of the function that was used to initialize it.

Perhaps there's something I'm not understanding there or the feature isn't working the way I think that it says it's supposed to.