### PR TITLE
Refactor Factory -> FactoryKit

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@
 import PackageDescription
 
 let package = Package(
-    name: "Factory",
+    name: "FactoryKit",
     platforms: [
         .iOS(.v12),
         .macOS(.v10_14),
@@ -15,8 +15,8 @@ let package = Package(
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
-            name: "Factory",
-            targets: ["Factory"]
+            name: "FactoryKit",
+            targets: ["FactoryKit"]
         ),
     ],
     dependencies: [
@@ -27,13 +27,13 @@ let package = Package(
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
-            name: "Factory",
+            name: "FactoryKit",
             dependencies: [],
             resources: [.copy("PrivacyInfo.xcprivacy")]
         ),
         .testTarget(
             name: "FactoryTests",
-            dependencies: ["Factory"]
+            dependencies: ["FactoryKit"]
         )
     ],
     swiftLanguageVersions: [


### PR DESCRIPTION
This PR renames the Factory module to FactoryKit to resolve the issue that xcodebuild adds a Factory. prefix to the Factory type since it's named the same as the module. This change makes the module have a different name and hence xcodebuild doesn't add the Factory. prefix so Factory compiles well.

The issue of the sift compiler adding the module prefix is described here: https://github.com/swiftlang/swift/issues/56573