### PR TITLE
[Closes #265] Injection of viewmodel when @Observable not working properly

### DIFF
--- a/Tests/FactoryTests/FactoryInjectionTests.swift
+++ b/Tests/FactoryTests/FactoryInjectionTests.swift
@@ -294,6 +294,26 @@ final class FactoryInjectionTests: XCTestCase {
         let projected = i3.projectedValue
         XCTAssertNotNil(projected)
     }
+    
+    @available(iOS 17, *)
+    @MainActor
+    func testInjectedObservable() throws {
+        // Test initializer for default container
+        let i1 = InjectedObservable(\.contentObservableViewModel)
+        let cvm1 = i1.wrappedValue
+        XCTAssertEqual(cvm1.text, "Test")
+        // Test initializer for custom container
+        let i2 = InjectedObservable(\CustomContainer.contentObservableViewModel)
+        let cvm2 = i2.wrappedValue
+        XCTAssertEqual(cvm2.text, "Test")
+        // Test initializer for passed parameter
+        let i3 = InjectedObservable(ContentObservableViewModel())
+        let cvm3 = i3.wrappedValue
+        XCTAssertEqual(cvm3.text, "Test")
+        // Test projected value
+        let projected = i3.projectedValue
+        XCTAssertNotNil(projected)
+    }
     #endif
 
 }
@@ -323,6 +343,26 @@ class ResolvingViewModel: ObservableObject {
 }
 
 extension Container: Resolving {}
+
+@available(iOS 17, *)
+@Observable
+class ContentObservableViewModel {
+    var text = "Test"
+}
+
+@available(iOS 17, *)
+extension Container {
+    var contentObservableViewModel: Factory<ContentObservableViewModel> {
+        self { ContentObservableViewModel() }
+    }
+}
+
+@available(iOS 17, *)
+extension CustomContainer {
+    var contentObservableViewModel: Factory<ContentObservableViewModel> {
+        self { ContentObservableViewModel() }
+    }
+}
 
 #endif
 


### PR DESCRIPTION
This pull request introduces a new property wrapper `InjectedObservable` to manage observable dependencies in SwiftUI views and includes tests to verify its functionality. The most important changes include the addition of the `InjectedObservable` property wrapper, updates to the test suite, and the creation of a new observable view model.

### New Property Wrapper for Dependency Injection:

* [`Sources/Factory/Factory/Injections.swift`](diffhunk://#diff-cca26ca50b61e1f81868ed3ac5174aed807709bd2c20050d4d3458909bb9dd92R390-R447): Introduced the `InjectedObservable` property wrapper, which resolves and injects observable dependencies from a shared container into SwiftUI views. This wrapper supports iOS 17.0, macOS 14.0, tvOS 17.0, and watchOS 10.0.

### Test Suite Enhancements:

* [`Tests/FactoryTests/FactoryInjectionTests.swift`](diffhunk://#diff-1f32667914a56471eca70f540ede729f93540d69c123c5d6def7ba3c4a7b09d2R297-R316): Added a new test case `testInjectedObservable` to verify the functionality of the `InjectedObservable` property wrapper, including initialization from both default and custom containers, as well as direct parameter passing.

### New Observable View Model:

* [`Tests/FactoryTests/FactoryInjectionTests.swift`](diffhunk://#diff-1f32667914a56471eca70f540ede729f93540d69c123c5d6def7ba3c4a7b09d2R347-R366): Created the `ContentObservableViewModel` class conforming to the `Observable` protocol and added it to both the default `Container` and a custom container for dependency resolution.