### PR TITLE
Add trait with registration

### DIFF
--- a/Sources/Factory/Factory/ContainerTrait.swift
+++ b/Sources/Factory/Factory/ContainerTrait.swift
@@ -44,8 +44,22 @@ public struct ContainerTrait: TestTrait, TestScoping {
 }
 
 public extension Trait where Self == ContainerTrait {
+    /// Provides a new isolated instance of the `Container.shared` for the test.
     static var container: Self {
         Self(value: Container())
+    }
+
+    /// Use the closure to register any dependencies for the test
+    ///
+    /// ```swift
+    /// @Test(.container {
+    ///    $0.myDependency.onTest { 1 }
+    /// })
+    /// ```
+    static func container(_ modify: (Container) -> Void) -> Self {
+        let container = Container()
+        modify(container)
+        return Self(value: container)
     }
 }
 #endif

--- a/Tests/FactoryTests/ParallelTests.swift
+++ b/Tests/FactoryTests/ParallelTests.swift
@@ -40,5 +40,14 @@ struct ParallelTests {
         let result = sut.execute()
         #expect(result == "baz")
     }
+
+    @Test(.container {
+        $0.fooBarBaz.register { Baz() }
+    })
+    func testRegistration() {
+        let sut = SomeUseCase()
+        let result = sut.execute()
+        #expect(result == "baz")
+    }
 }
 #endif


### PR DESCRIPTION
Add a new `TestTrait` helper function that allows registration of dependencies at trait declaration.

The motivation of this is to introduce the ability to register dependencies at trait declaration. This can be helpful for some type of dependencies. While it might not be as good for mocks where the instances are needed within the test, having this option provides a nice syntax.

```swift
@Suite
struct Tests {
  let subject = ObjectThatUsesID()

  @Test(.container)
  func test() {
    Container.shared.id.onTest { "123" }
    
    #expect(object.id == "123")
  }
}
```

This becomes

```swift
@Suite
struct Tests {
  let subject = ObjectThatUsesID()

  @Test(.container {
    $0.id.onTest { "123" }
  })
  func test() {
    #expect(object.id == "123")
  }
}
```

This change maintains compatibility with the existing code and does not break any existing functionality.