### PR TITLE
Container test trait to support Singleton scope resetting

### DIFF
--- a/Sources/Factory/Factory/ContainerTrait.swift
+++ b/Sources/Factory/Factory/ContainerTrait.swift
@@ -40,10 +40,8 @@ public struct ContainerTrait: TestTrait, TestScoping {
     public func provideScope(for test: Test, testCase: Test.Case?, performing function: () async throws -> Void) async throws {
         try await Container.$shared.withValue(value) {
             if resetSingletonScope {
-                let singletonScope = Scope.Singleton()
-                // Reset the singleton scope for this test
-                singletonScope.reset()
-                try await Scope.$singleton.withValue(singletonScope) {
+                try await Scope.$singleton.withValue(Scope.Singleton()) {
+                    Scope.singleton.reset()
                     try await function()
                 }
             } else {

--- a/Sources/Factory/Factory/Scopes.swift
+++ b/Sources/Factory/Factory/Scopes.swift
@@ -157,7 +157,7 @@ extension Scope {
         }
     }
 
-    /// A reference to the default singleton scope manager.
+    /// A reference to the default singleton scope manager. Using its `@TaskLocal` macro provided capabilities should only be used in tests to enable parallel testing.
     @TaskLocal public static var singleton = Singleton()
     /// Defines the singleton scope. The same instance will always be returned by the factory.
     public final class Singleton: Scope, InternalScopeCaching, @unchecked Sendable  {

--- a/Sources/Factory/Factory/Scopes.swift
+++ b/Sources/Factory/Factory/Scopes.swift
@@ -158,7 +158,7 @@ extension Scope {
     }
 
     /// A reference to the default singleton scope manager.
-    public static let singleton = Singleton()
+    @TaskLocal public static var singleton = Singleton()
     /// Defines the singleton scope. The same instance will always be returned by the factory.
     public final class Singleton: Scope, InternalScopeCaching, @unchecked Sendable  {
         public override init() {

--- a/Sources/Factory/Factory/Scopes.swift
+++ b/Sources/Factory/Factory/Scopes.swift
@@ -158,7 +158,12 @@ extension Scope {
     }
 
     /// A reference to the default singleton scope manager. Using its `@TaskLocal` macro provided capabilities should only be used in tests to enable parallel testing.
+#if swift(>=6.1)
     @TaskLocal public static var singleton = Singleton()
+#else
+    public static let singleton = Singleton()
+#endif
+
     /// Defines the singleton scope. The same instance will always be returned by the factory.
     public final class Singleton: Scope, InternalScopeCaching, @unchecked Sendable  {
         public override init() {

--- a/Tests/FactoryTests/MockServices.swift
+++ b/Tests/FactoryTests/MockServices.swift
@@ -261,6 +261,9 @@ final class Baz: FooBarBazProtocol {
 
 extension Container {
     var fooBarBaz: Factory<FooBarBazProtocol> {
+        self { Foo() }
+    }
+    var fooBarBazSingleton: Factory<FooBarBazProtocol> {
         self { Foo() }.singleton
     }
 }
@@ -270,5 +273,11 @@ final class SomeUseCase {
         @Injected(\.fooBarBaz) var fooBarBaz: FooBarBazProtocol
 
         return fooBarBaz.value
+    }
+
+    func executeSingleton() -> String {
+        @Injected(\.fooBarBazSingleton) var fooBarBazSingleton: FooBarBazProtocol
+
+        return fooBarBazSingleton.value
     }
 }

--- a/Tests/FactoryTests/MockServices.swift
+++ b/Tests/FactoryTests/MockServices.swift
@@ -261,7 +261,7 @@ final class Baz: FooBarBazProtocol {
 
 extension Container {
     var fooBarBaz: Factory<FooBarBazProtocol> {
-        self { Foo() }
+        self { Foo() }.singleton
     }
 }
 

--- a/Tests/FactoryTests/ParallelTests.swift
+++ b/Tests/FactoryTests/ParallelTests.swift
@@ -5,7 +5,7 @@ import Testing
 
 @Suite
 struct ParallelTests {
-    @Test(.container())
+    @Test(.container(resetSingletonScope: false))
     func foo() {
         let sut = SomeUseCase()
 
@@ -17,7 +17,7 @@ struct ParallelTests {
         #expect(result == "foo")
     }
 
-    @Test(.container())
+    @Test(.container(resetSingletonScope: false))
     func bar() {
         let sut = SomeUseCase()
 
@@ -29,7 +29,7 @@ struct ParallelTests {
         #expect(result == "bar")
     }
 
-    @Test(.container())
+    @Test(.container(resetSingletonScope: false))
     func baz() {
         let sut = SomeUseCase()
 
@@ -38,6 +38,42 @@ struct ParallelTests {
         }
 
         let result = sut.execute()
+        #expect(result == "baz")
+    }
+
+    @Test(.container())
+    func fooSingleton() {
+        let sut = SomeUseCase()
+
+        Container.shared.fooBarBazSingleton.register {
+            Foo()
+        }
+
+        let result = sut.executeSingleton()
+        #expect(result == "foo")
+    }
+
+    @Test(.container())
+    func barSingleton() {
+        let sut = SomeUseCase()
+
+        Container.shared.fooBarBazSingleton.register {
+            Bar()
+        }
+
+        let result = sut.executeSingleton()
+        #expect(result == "bar")
+    }
+
+    @Test(.container())
+    func bazSingleton() {
+        let sut = SomeUseCase()
+
+        Container.shared.fooBarBazSingleton.register {
+            Baz()
+        }
+
+        let result = sut.executeSingleton()
         #expect(result == "baz")
     }
 }

--- a/Tests/FactoryTests/ParallelTests.swift
+++ b/Tests/FactoryTests/ParallelTests.swift
@@ -5,7 +5,7 @@ import Testing
 
 @Suite
 struct ParallelTests {
-    @Test(.container)
+    @Test(.container())
     func foo() {
         let sut = SomeUseCase()
 
@@ -17,7 +17,7 @@ struct ParallelTests {
         #expect(result == "foo")
     }
 
-    @Test(.container)
+    @Test(.container())
     func bar() {
         let sut = SomeUseCase()
 
@@ -29,7 +29,7 @@ struct ParallelTests {
         #expect(result == "bar")
     }
 
-    @Test(.container)
+    @Test(.container())
     func baz() {
         let sut = SomeUseCase()
 


### PR DESCRIPTION
### Motivation
With the adjustments of PR https://github.com/hmlongco/Factory/pull/272 it became possible to enable parallel testing via Swift Testing's `TestTrait` and `TestScoping`. However it didn't support the resetting of the singleton scope. To achieve full support for test parallelization Factory should provide a way for this as well.

### Implementation
With this PR, tests that depend on the same singleton can also run in parallel via the `resetSingletonScope` input parameter of the `.container()` trait (which also became a static function to handle this situation properly). Its default value is set to debatably the more foolproof option `true`.

### Usage
```
@Test(.container()) //resetSingletonScope is true by default
...
@Test(.container(resetSingletonScope: true)) //resetSingletonScope is true explicitly
...
@Test(.container(resetSingletonScope: false)) //if the test doesn't deal with singletons then with this we can opt-out from the resetting
...
```

### Decision
To enable this I had to change `Scope.singleton` which used to be `static let`, to become `@TaskLocal static var`. In its documentation I highlighted however that one should only use its `@TaskLocal` feature in tests to avoid unpredictable behavior.

I forgot to mention this as a future direction in the original PR, but this is definitely one of the most important parts in my opinion.

Edit: formatting
Edit2: mention missed future direction in the original PR
