### PR TITLE
Add inline registration sugar to ContainerTrait AND fix parallelization issue

### DIFF
--- a/Sources/Factory/Factory/ContainerTrait.swift
+++ b/Sources/Factory/Factory/ContainerTrait.swift
@@ -48,14 +48,28 @@ public struct ContainerTrait<C: SharedContainer>: TestTrait, TestScoping {
     }
 }
 
-/// Provides test trait for default container
 extension Container {
+    /// Provides test trait for default container
     public static var taskLocalTestTrait: ContainerTrait<Container> { .init(shared: $shared, container: .init()) }
+
+    /// Provides test trait for default container, with modifications
+    public static func taskLocalTestTrait(_ modify: @Sendable (Container) -> Void) -> ContainerTrait<Container> {
+        let container = Container()
+        modify(container)
+        return .init(shared: $shared, container: container)
+    }
 }
 
-/// Convenience extension provides test trait for autocomplete
 extension Trait where Self == ContainerTrait<Container>{
+    /// Convenience extension provides test trait for autocomplete
     static var container: ContainerTrait<Container> { Container.taskLocalTestTrait }
+
+    /// Convenience extension provides test trait with modifications for autocomplete
+    static func container(_ modify: @Sendable (Container) -> Void) -> Self {
+        let container = Container()
+        modify(container)
+        return Self(shared: Container.$shared, container: container)
+    }
 }
 
 #endif

--- a/Sources/Factory/Factory/ContainerTrait.swift
+++ b/Sources/Factory/Factory/ContainerTrait.swift
@@ -58,7 +58,7 @@ extension Container {
     public static func taskLocalTestTrait(_ modify: @escaping @Sendable (Container) -> Void) -> ContainerTrait<Container> { .init(shared: $shared, container: Container.self, modify: modify) }
 }
 
-extension Trait where Self == ContainerTrait<Container>{
+public extension Trait where Self == ContainerTrait<Container>{
     /// Convenience extension provides test trait for autocomplete
     static var container: ContainerTrait<Container> { Container.taskLocalTestTrait }
 

--- a/Sources/Factory/Factory/ContainerTrait.swift
+++ b/Sources/Factory/Factory/ContainerTrait.swift
@@ -38,11 +38,11 @@ import Testing
 /// See examples in the ``ParallelXCTests`` file.
 public struct ContainerTrait<C: SharedContainer>: TestTrait, TestScoping {
     let shared: TaskLocal<C>
-    let container: C
+    let container: C.Type
     var modify: (@Sendable (C) -> Void)? = nil
     public func provideScope(for test: Test, testCase: Test.Case?, performing function: () async throws -> Void) async throws {
         try await Scope.$singleton.withValue(Scope.singleton.clone()) {
-            try await shared.withValue(container) {
+            try await shared.withValue(container.init()) {
                 modify?(shared.wrappedValue)
                 try await function()
             }
@@ -52,10 +52,10 @@ public struct ContainerTrait<C: SharedContainer>: TestTrait, TestScoping {
 
 extension Container {
     /// Provides test trait for default container
-    public static var taskLocalTestTrait: ContainerTrait<Container> { .init(shared: $shared, container: .init()) }
+    public static var taskLocalTestTrait: ContainerTrait<Container> { .init(shared: $shared, container: Container.self) }
 
     /// Provides test trait for default container, with modifications
-    public static func taskLocalTestTrait(_ modify: @escaping @Sendable (Container) -> Void) -> ContainerTrait<Container> { .init(shared: $shared, container: .init(), modify: modify) }
+    public static func taskLocalTestTrait(_ modify: @escaping @Sendable (Container) -> Void) -> ContainerTrait<Container> { .init(shared: $shared, container: Container.self, modify: modify) }
 }
 
 extension Trait where Self == ContainerTrait<Container>{

--- a/Sources/Factory/Factory/ContainerTrait.swift
+++ b/Sources/Factory/Factory/ContainerTrait.swift
@@ -70,6 +70,15 @@ extension Trait where Self == ContainerTrait<Container>{
         modify(container)
         return Self(shared: Container.$shared, container: container)
     }
+
+    @MainActor
+    static func isolatedContainer(
+        _ modify: @MainActor (Container) async -> Void
+    ) async -> Self {
+        let container = Container()
+        await modify(container)
+        return Self(shared: Container.$shared, container: container)
+    }
 }
 
 #endif

--- a/Sources/Factory/Factory/ContainerTrait.swift
+++ b/Sources/Factory/Factory/ContainerTrait.swift
@@ -70,15 +70,6 @@ extension Trait where Self == ContainerTrait<Container>{
         modify(container)
         return Self(shared: Container.$shared, container: container)
     }
-
-    @MainActor
-    static func isolatedContainer(
-        _ modify: @MainActor (Container) async -> Void
-    ) async -> Self {
-        let container = Container()
-        await modify(container)
-        return Self(shared: Container.$shared, container: container)
-    }
 }
 
 #endif

--- a/Sources/Factory/Factory/Containers.swift
+++ b/Sources/Factory/Factory/Containers.swift
@@ -79,6 +79,10 @@ public protocol SharedContainer: ManagedContainer {
     /// Using 'static var' (without @TaskLocal being attached to it) will cause Swift to issue concurrency warnings in the future whenever the container is accessed.
     static var shared: Self { get }
 
+    /// Needed to enable parallel testing via the `ContainerTrait`. `ContainerTrait` uses a generic parameter that is constrained to `SharedContainer`.
+    /// Thus it can be used with custom containers and the default `Container` as well.
+    /// To enable parallel testing `ContainerTrait` has to be able to access the initializer of the given container to make sure that every `@TaskLocal` isolated scenario has its own `SharedContainer` instance.
+    init()
 }
 
 // MARK: - ManagedContainer

--- a/Tests/FactoryTests/MockServices.swift
+++ b/Tests/FactoryTests/MockServices.swift
@@ -276,6 +276,29 @@ final class Baz: FooBarBazProtocol {
     var value = "baz"
 }
 
+// Classes for isolated @TaskLocal and TestTrait tests
+
+@MainActor
+protocol IsolatedFooBarBazProtocol: Sendable {
+    var id: UUID { get }
+    var value: String { get set }
+}
+
+final class IsolatedFoo: IsolatedFooBarBazProtocol {
+    let id: UUID = UUID()
+    var value = "foo"
+}
+
+final class IsolatedBar: IsolatedFooBarBazProtocol {
+    let id: UUID = UUID()
+    var value = "bar"
+}
+
+final class IsolatedBaz: IsolatedFooBarBazProtocol {
+    let id: UUID = UUID()
+    var value = "baz"
+}
+
 extension Container {
     var fooBarBaz: Factory<FooBarBazProtocol> {
         self { Foo() }
@@ -286,10 +309,29 @@ extension Container {
     var fooBarBazSingleton: Factory<FooBarBazProtocol> {
         self { Foo() }.singleton
     }
+    @MainActor
+    var isolatedFooBarBaz: Factory<IsolatedFooBarBazProtocol> {
+        self { IsolatedFoo() }
+    }
+    @MainActor
+    var isolatedFooBarBazCached: Factory<IsolatedFooBarBazProtocol> {
+        self { IsolatedFoo() }.cached
+    }
+    @MainActor
+    var isolatedFooBarBazSingleton: Factory<IsolatedFooBarBazProtocol> {
+        self { IsolatedFoo() }.singleton
+    }
 }
 
 final class TaskLocalUseCase {
     @Injected(\.fooBarBaz) var fooBarBaz: FooBarBazProtocol
     @Injected(\.fooBarBazCached) var fooBarBazCached: FooBarBazProtocol
     @Injected(\.fooBarBazSingleton) var fooBarBazSingleton: FooBarBazProtocol
+}
+
+@MainActor
+final class IsolatedTaskLocalUseCase: Sendable {
+    @Injected(\.isolatedFooBarBaz) var isolatedFooBarBaz: IsolatedFooBarBazProtocol
+    @Injected(\.isolatedFooBarBazCached) var isolatedFooBarBazCached: IsolatedFooBarBazProtocol
+    @Injected(\.isolatedFooBarBazSingleton) var isolatedFooBarBazSingleton: IsolatedFooBarBazProtocol
 }

--- a/Tests/FactoryTests/MockServices.swift
+++ b/Tests/FactoryTests/MockServices.swift
@@ -276,29 +276,6 @@ final class Baz: FooBarBazProtocol {
     var value = "baz"
 }
 
-// Classes for isolated @TaskLocal and TestTrait tests
-
-@MainActor
-protocol IsolatedFooBarBazProtocol: Sendable {
-    var id: UUID { get }
-    var value: String { get set }
-}
-
-final class IsolatedFoo: IsolatedFooBarBazProtocol {
-    let id: UUID = UUID()
-    var value = "foo"
-}
-
-final class IsolatedBar: IsolatedFooBarBazProtocol {
-    let id: UUID = UUID()
-    var value = "bar"
-}
-
-final class IsolatedBaz: IsolatedFooBarBazProtocol {
-    let id: UUID = UUID()
-    var value = "baz"
-}
-
 extension Container {
     var fooBarBaz: Factory<FooBarBazProtocol> {
         self { Foo() }
@@ -309,29 +286,10 @@ extension Container {
     var fooBarBazSingleton: Factory<FooBarBazProtocol> {
         self { Foo() }.singleton
     }
-    @MainActor
-    var isolatedFooBarBaz: Factory<IsolatedFooBarBazProtocol> {
-        self { IsolatedFoo() }
-    }
-    @MainActor
-    var isolatedFooBarBazCached: Factory<IsolatedFooBarBazProtocol> {
-        self { IsolatedFoo() }.cached
-    }
-    @MainActor
-    var isolatedFooBarBazSingleton: Factory<IsolatedFooBarBazProtocol> {
-        self { IsolatedFoo() }.singleton
-    }
 }
 
 final class TaskLocalUseCase {
     @Injected(\.fooBarBaz) var fooBarBaz: FooBarBazProtocol
     @Injected(\.fooBarBazCached) var fooBarBazCached: FooBarBazProtocol
     @Injected(\.fooBarBazSingleton) var fooBarBazSingleton: FooBarBazProtocol
-}
-
-@MainActor
-final class IsolatedTaskLocalUseCase: Sendable {
-    @Injected(\.isolatedFooBarBaz) var isolatedFooBarBaz: IsolatedFooBarBazProtocol
-    @Injected(\.isolatedFooBarBazCached) var isolatedFooBarBazCached: IsolatedFooBarBazProtocol
-    @Injected(\.isolatedFooBarBazSingleton) var isolatedFooBarBazSingleton: IsolatedFooBarBazProtocol
 }

--- a/Tests/FactoryTests/MockServices.swift
+++ b/Tests/FactoryTests/MockServices.swift
@@ -245,7 +245,7 @@ final class CustomContainer: SharedContainer, AutoRegistering {
 #if swift(>=6.1)
 /// Provides test trait for custom container
 extension CustomContainer {
-    public static var taskLocalTestTrait: ContainerTrait<CustomContainer> { .init(shared: $shared, container: .init()) }
+    public static var taskLocalTestTrait: ContainerTrait<CustomContainer> { .init(shared: $shared, container: CustomContainer.self) }
 }
 
 /// Provides test trait for custom container's autocomplete

--- a/Tests/FactoryTests/ParallelTests.swift
+++ b/Tests/FactoryTests/ParallelTests.swift
@@ -84,5 +84,34 @@ struct ParallelTests {
         #expect(sut3.fooBarBazSingleton.value == "foo")
         #expect(sut1.fooBarBazSingleton.id != sut3.fooBarBazSingleton.id)
     }
+
+    // Illustrates using autocomplete test trait with modifications on isolated registrations
+    @MainActor
+    @Test(await .isolatedContainer {
+        $0.isolatedFooBarBaz.register { IsolatedBaz() }
+        $0.isolatedFooBarBazCached.register { IsolatedBaz() }
+        $0.isolatedFooBarBazSingleton.register { IsolatedBaz() }
+    })
+    func isolatedBaz() async {
+        let sut1 = IsolatedTaskLocalUseCase()
+        #expect(sut1.isolatedFooBarBaz.value == "baz")
+        #expect(sut1.isolatedFooBarBazCached.value == "baz")
+        #expect(sut1.isolatedFooBarBazSingleton.value == "baz")
+
+        let sut2 = IsolatedTaskLocalUseCase()
+        #expect(sut2.isolatedFooBarBaz.value == "baz")
+        #expect(sut2.isolatedFooBarBazCached.value == "baz")
+        #expect(sut2.isolatedFooBarBazSingleton.value == "baz")
+
+        #expect(sut1.isolatedFooBarBaz.id != sut2.isolatedFooBarBaz.id)
+        #expect(sut1.isolatedFooBarBazCached.id == sut2.isolatedFooBarBazCached.id)
+        #expect(sut1.isolatedFooBarBazSingleton.id == sut2.isolatedFooBarBazSingleton.id)
+
+        Container.shared.isolatedFooBarBazSingleton.register { IsolatedFoo() }
+
+        let sut3 = IsolatedTaskLocalUseCase()
+        #expect(sut3.isolatedFooBarBazSingleton.value == "foo")
+        #expect(sut1.isolatedFooBarBazSingleton.id != sut3.isolatedFooBarBazSingleton.id)
+    }
 }
 #endif

--- a/Tests/FactoryTests/ParallelTests.swift
+++ b/Tests/FactoryTests/ParallelTests.swift
@@ -57,13 +57,13 @@ struct ParallelTests {
         #expect(sut1.fooBarBazSingleton.id != sut3.fooBarBazSingleton.id)
     }
 
-    // Illustrates using autocomplete test trait
-    @Test(.container)
+    // Illustrates using autocomplete test trait with modifications
+    @Test(.container {
+        $0.fooBarBaz.register { Baz() }
+        $0.fooBarBazCached.register { Baz() }
+        $0.fooBarBazSingleton.register { Baz() }
+    })
     func baz() {
-        Container.shared.fooBarBaz.register { Baz() }
-        Container.shared.fooBarBazCached.register { Baz() }
-        Container.shared.fooBarBazSingleton.register { Baz() }
-
         let sut1 = TaskLocalUseCase()
         #expect(sut1.fooBarBaz.value == "baz")
         #expect(sut1.fooBarBazCached.value == "baz")

--- a/Tests/FactoryTests/ParallelTests.swift
+++ b/Tests/FactoryTests/ParallelTests.swift
@@ -84,34 +84,5 @@ struct ParallelTests {
         #expect(sut3.fooBarBazSingleton.value == "foo")
         #expect(sut1.fooBarBazSingleton.id != sut3.fooBarBazSingleton.id)
     }
-
-    // Illustrates using autocomplete test trait with modifications on isolated registrations
-    @MainActor
-    @Test(await .isolatedContainer {
-        $0.isolatedFooBarBaz.register { IsolatedBaz() }
-        $0.isolatedFooBarBazCached.register { IsolatedBaz() }
-        $0.isolatedFooBarBazSingleton.register { IsolatedBaz() }
-    })
-    func isolatedBaz() async {
-        let sut1 = IsolatedTaskLocalUseCase()
-        #expect(sut1.isolatedFooBarBaz.value == "baz")
-        #expect(sut1.isolatedFooBarBazCached.value == "baz")
-        #expect(sut1.isolatedFooBarBazSingleton.value == "baz")
-
-        let sut2 = IsolatedTaskLocalUseCase()
-        #expect(sut2.isolatedFooBarBaz.value == "baz")
-        #expect(sut2.isolatedFooBarBazCached.value == "baz")
-        #expect(sut2.isolatedFooBarBazSingleton.value == "baz")
-
-        #expect(sut1.isolatedFooBarBaz.id != sut2.isolatedFooBarBaz.id)
-        #expect(sut1.isolatedFooBarBazCached.id == sut2.isolatedFooBarBazCached.id)
-        #expect(sut1.isolatedFooBarBazSingleton.id == sut2.isolatedFooBarBazSingleton.id)
-
-        Container.shared.isolatedFooBarBazSingleton.register { IsolatedFoo() }
-
-        let sut3 = IsolatedTaskLocalUseCase()
-        #expect(sut3.isolatedFooBarBazSingleton.value == "foo")
-        #expect(sut1.isolatedFooBarBazSingleton.id != sut3.isolatedFooBarBazSingleton.id)
-    }
 }
 #endif


### PR DESCRIPTION
### Description
This PR contains two things. Which is obviously not ideal, but the second issue I noticed during the implementation of the first one, hence they're in one PR.
1. (original) Adds registration sugar to `TestTrait`
2. (discovered on the fly) Fixes an issue with parallelization

## 1. Registration Sugar

### Motivation
`ContainerTrait` enables parallel test running by using `@Test(.container)`, and then in the function body we can override registrations. To make it one step nicer this PR enables devs to lift those registrations to the trailing closure of a new `.container` with the below syntax:
```
    @Test(.container {
        $0.fooBarBaz.register { Baz() }
        $0.fooBarBazCached.register { Baz() }
        $0.fooBarBazSingleton.register { Baz() }
    })
    func baz() {...}
```
it is basically the same as below:
```
@Test(.container)
    func baz() {
        Container.shared.fooBarBaz.register { Baz() }
        Container.shared.fooBarBazCached.register { Baz() }
        Container.shared.fooBarBazSingleton.register { Baz() }
        ...
        }
```

### Credit
This PR basically reopens this one: https://github.com/hmlongco/Factory/pull/280

### Decision
With the implementation of this PR we have two `container` traits, while we could have just one, by making the second one's `modify` closure parameter optional and defaulted to `nil`.

### Future directions
See commit: 68ffee77c326fa1f361c65c005038f87fe097fd2 where I played with the idea of supporting isolated registrations in this `modify` trailing closure. While it might be nice, I'm not sure if this is really that needed. I'm looking for feedback here. If anyone needs that, it's quite easy to implement it yourself for your global actor or just copy this one over for MainActor. What I struggled to figure out was to make more generic, so to not support only MainActor isolation but any actor. I'm aware of the `#isolation` macro but I couldn't make it work to support any global actor, however it might be possible.

## 2. Parallelization issue

I ran the tests on the `main` repeatedly and it failed every second time. I first thought that this is due to a problem with the singleton scope handling of the `ContainerTrait`, but it turned out to be an issue with the passing of the `SharedContainer` instance. 

It turned out that it is unsafe to pass (at least reference types like `Container`) even to a `@TaskLocal.withValue`. 

To fix that I changed the 
`let container: C` 
to be 
`let container: C.Type` 
and then 
`try await shared.withValue(container)`
to be 
`try await shared.withValue(container.init())` 

### ⚠️Breaking Change⚠️

This became only possible by adding an explicit `init` requirement to the `SharedContainer`, which will be a **breaking change** for most of the users. However I think it is reasonable. I'm not sure about alternatives that can keep the support for `any SharedContainer`.