### PR TITLE
Enable SuiteTrait

### DIFF
--- a/Sources/Factory/Factory/ContainerTrait.swift
+++ b/Sources/Factory/Factory/ContainerTrait.swift
@@ -37,7 +37,7 @@ import Testing
 ///
 /// That said, it's also possible to leverage this behavior in `XCTestCase`, by using the `@TaskLocal` provided `withValue` method.
 /// See examples in the ``ParallelXCTests`` file.
-public struct ContainerTrait<C: SharedContainer>: TestTrait, TestScoping {
+public struct ContainerTrait<C: SharedContainer>: TestTrait, SuiteTrait, TestScoping {
 
     public typealias Transform = @Sendable (C) -> Void
 
@@ -45,6 +45,7 @@ public struct ContainerTrait<C: SharedContainer>: TestTrait, TestScoping {
     let container: @Sendable () -> C
 
     var transform: Transform? = nil
+    public let isRecursive: Bool = true
 
     public init(shared: TaskLocal<C>, container: @autoclosure @escaping @Sendable () -> C) {
         self.shared = shared

--- a/Tests/FactoryTests/ParallelTests.swift
+++ b/Tests/FactoryTests/ParallelTests.swift
@@ -86,4 +86,91 @@ struct ParallelTests {
         #expect(sut1.fooBarBazSingleton.id != sut3.fooBarBazSingleton.id)
     }
 }
+
+extension ParallelTests {
+    // Illustrates using container test trait for the entire suite
+    @Suite(.container)
+    struct SuiteTraitTests {
+        @Test
+        func foo() {
+            Container.shared.fooBarBaz.register { Foo() }
+            Container.shared.fooBarBazCached.register { Foo() }
+            Container.shared.fooBarBazSingleton.register { Foo() }
+
+            let sut1 = TaskLocalUseCase()
+            #expect(sut1.fooBarBaz.value == "foo")
+            #expect(sut1.fooBarBazCached.value == "foo")
+            #expect(sut1.fooBarBazSingleton.value == "foo")
+
+            let sut2 = TaskLocalUseCase()
+            #expect(sut2.fooBarBaz.value == "foo")
+            #expect(sut2.fooBarBazCached.value == "foo")
+            #expect(sut2.fooBarBazSingleton.value == "foo")
+
+            #expect(sut1.fooBarBaz.id != sut2.fooBarBaz.id)
+            #expect(sut1.fooBarBazCached.id == sut2.fooBarBazCached.id)
+            #expect(sut1.fooBarBazSingleton.id == sut2.fooBarBazSingleton.id)
+
+            Container.shared.fooBarBazSingleton.register { Bar() }
+
+            let sut3 = TaskLocalUseCase()
+            #expect(sut3.fooBarBazSingleton.value == "bar")
+            #expect(sut1.fooBarBazSingleton.id != sut3.fooBarBazSingleton.id)
+        }
+
+        @Test
+        func bar() {
+            Container.shared.fooBarBaz.register { Bar() }
+            Container.shared.fooBarBazCached.register { Bar() }
+            Container.shared.fooBarBazSingleton.register { Bar() }
+
+            let sut1 = TaskLocalUseCase()
+            #expect(sut1.fooBarBaz.value == "bar")
+            #expect(sut1.fooBarBazCached.value == "bar")
+            #expect(sut1.fooBarBazSingleton.value == "bar")
+
+            let sut2 = TaskLocalUseCase()
+            #expect(sut2.fooBarBaz.value == "bar")
+            #expect(sut2.fooBarBazCached.value == "bar")
+            #expect(sut2.fooBarBazSingleton.value == "bar")
+
+            #expect(sut1.fooBarBaz.id != sut2.fooBarBaz.id)
+            #expect(sut1.fooBarBazCached.id == sut2.fooBarBazCached.id)
+            #expect(sut1.fooBarBazSingleton.id == sut2.fooBarBazSingleton.id)
+
+            Container.shared.fooBarBazSingleton.register { Foo() }
+
+            let sut3 = TaskLocalUseCase()
+            #expect(sut3.fooBarBazSingleton.value == "foo")
+            #expect(sut1.fooBarBazSingleton.id != sut3.fooBarBazSingleton.id)
+        }
+
+        @Test
+        func baz() {
+            Container.shared.fooBarBaz.register { Baz() }
+            Container.shared.fooBarBazCached.register { Baz() }
+            Container.shared.fooBarBazSingleton.register { Baz() }
+
+            let sut1 = TaskLocalUseCase()
+            #expect(sut1.fooBarBaz.value == "baz")
+            #expect(sut1.fooBarBazCached.value == "baz")
+            #expect(sut1.fooBarBazSingleton.value == "baz")
+
+            let sut2 = TaskLocalUseCase()
+            #expect(sut2.fooBarBaz.value == "baz")
+            #expect(sut2.fooBarBazCached.value == "baz")
+            #expect(sut2.fooBarBazSingleton.value == "baz")
+
+            #expect(sut1.fooBarBaz.id != sut2.fooBarBaz.id)
+            #expect(sut1.fooBarBazCached.id == sut2.fooBarBazCached.id)
+            #expect(sut1.fooBarBazSingleton.id == sut2.fooBarBazSingleton.id)
+
+            Container.shared.fooBarBazSingleton.register { Bar() }
+
+            let sut3 = TaskLocalUseCase()
+            #expect(sut3.fooBarBazSingleton.value == "bar")
+            #expect(sut1.fooBarBazSingleton.id != sut3.fooBarBazSingleton.id)
+        }
+    }
+}
 #endif


### PR DESCRIPTION
Adding support for `SuiteTrait` to enable adding the `.container` trait to the entire `@Suite` so that all tests contained within the suite automatically get a fresh container for each test. 

This is done by enabling the `isRecursive` option. Which effectively recursively applies the trait to each individual test. But this will simplify the usage such that someone only has to apply the trait once to the whole suite and all tests within the suite automatically always get an isolated shared container and they can override properties without causing any issues.
Documentation: https://developer.apple.com/documentation/testing/suitetrait/isrecursive

I duplicated some tests in a container and without the `isRecursive` argument the tests would fail but with it the tests pass even when repeatedly 1000 times.