### PR TITLE
Introduce FactoryTestSupport to fix build errors

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,9 +31,13 @@ let package = Package(
             dependencies: [],
             resources: [.copy("PrivacyInfo.xcprivacy")]
         ),
+        .target(
+            name: "FactoryTestSupport",
+            dependencies: ["Factory"]
+        ),
         .testTarget(
             name: "FactoryTests",
-            dependencies: ["Factory"]
+            dependencies: ["Factory", "FactoryTestSupport"]
         )
     ],
     swiftLanguageVersions: [

--- a/Sources/Factory/Factory/Scopes.swift
+++ b/Sources/Factory/Factory/Scopes.swift
@@ -186,7 +186,7 @@ extension Scope {
             cache.reset()
         }
         /// For testing
-        internal func clone() -> Singleton {
+        package func clone() -> Singleton {
             .init(from: self)
         }
     }

--- a/Sources/FactoryTestSupport/ContainerTrait.swift
+++ b/Sources/FactoryTestSupport/ContainerTrait.swift
@@ -27,6 +27,7 @@
 #if DEBUG
 #if swift(>=6.1)
 
+import Factory
 import Testing
 
 /// ``ContainerTrait`` is a generic test trait that provides a scoped container for dependency injection in tests.

--- a/Tests/FactoryTests/MockServices.swift
+++ b/Tests/FactoryTests/MockServices.swift
@@ -8,6 +8,7 @@
 import Foundation
 import Testing
 @testable import Factory
+import FactoryTestSupport
 
 // Swift 6
 extension Container: AutoRegistering {


### PR DESCRIPTION
Currently `import Testing` is added part of `Factory` library but when used with iOS applications, accessing any swift `Testing` symbols causes a few linker errors about accessing undefined symbols. Here is one as an example `Undefined symbol: associated type descriptor for Testing.Trait.TestScopeProvider`

The only way to solve this is to make sure there are no `Testing` symbols used within the main application target. To solve this and still be able to provide the `ContainerTrait` to consumers, we can instead create a new library that consumers can optionally import in their testing targets. 

```swift
// package file
.product(name: "FactoryTestSupport", package: "Factory")
```

And in the test code

```swift
import Testing
import FactoryTestSupport

@Suite(.container)
struct DependencyTests {}
```