### PR TITLE
Docs for testTrait and some more

### DIFF
--- a/Sources/Factory/Factory.docc/Basics/Containers.md
+++ b/Sources/Factory/Factory.docc/Basics/Containers.md
@@ -46,6 +46,8 @@ public final class Container: SharedContainer {
 ```
 You've seen it used and extended in all of the examples we've seen thus far, and most projects can simply extend it and go.
 
+The real implementation of the default ``Container`` will have the `@TaskLocal macro` attaced to the `shared` static property if you're using Factory with Swift 5.5 or higher. See more in <doc:Testing>
+
 ## Container.shared
 
 As the default Container definition shows, each container class defined has a statically allocated `shared` instance associated with it.
@@ -99,7 +101,7 @@ Defining your own container class is simple. Just use the following as a templat
 
 ```swift
 public final class MyContainer: SharedContainer {
-     public static let shared = MyContainer()
+     @TaskLocal public static var shared = MyContainer()
      public let manager = ContainerManager()
 }
 
@@ -111,7 +113,13 @@ extension MyContainer {
 ```
 As mentioned, a container must derive from ``SharedContainer``, have its own ``ContainerManager``, and implement a static `shared` instance. It also must be marked `final`.
 
-> Note: Remember to define the "shared" container as a `let`, not `var`. Defining it as a `static var` will cause Swift to issue concurrency warnings in the future whenever that variable is accessed.
+> Note: Remember to define the "shared" container as a @TaskLocal variable to be able to use its isolation mechanism, which is especially useful for test parallelization.
+>
+> If you don't want to use the @TaskLocal isolation mechanism, then you should define a 'let' variable, not 'var'.
+>
+> Using 'static var' (without @TaskLocal being attached to it) will cause Swift to issue concurrency warnings in the future whenever the container is accessed.
+>
+> See <doc:Testing>
 
 ## Referencing Other Containers
 

--- a/Sources/Factory/Factory/ContainerTrait.swift
+++ b/Sources/Factory/Factory/ContainerTrait.swift
@@ -46,8 +46,7 @@ public struct ContainerTrait<C: SharedContainer>: TestTrait, SuiteTrait, TestSco
 
     private var transform: Transform? = nil
 
-    // If SuiteTrait then provideScope is called to provide a new container
-    // for each test in the suite.
+    /// If SuiteTrait then provideScope is called to provide a new container for each individual test and child suite in the suite.
     public let isRecursive: Bool = true
 
     public init(shared: TaskLocal<C>, container: @autoclosure @escaping @Sendable () -> C) {

--- a/Sources/Factory/Factory/Containers.swift
+++ b/Sources/Factory/Factory/Containers.swift
@@ -44,7 +44,7 @@ import Foundation
 ///  See <doc:Containers> for more information.
 public final class Container: SharedContainer {
     /// Define the default shared container.
-    #if swift(>=6.1)
+    #if swift(>=5.5)
     @TaskLocal public static var shared = Container()
     #else
     public static let shared = Container()

--- a/Sources/Factory/Factory/Scopes.swift
+++ b/Sources/Factory/Factory/Scopes.swift
@@ -158,7 +158,7 @@ extension Scope {
     }
 
     /// A reference to the default singleton scope manager.
-    #if swift(>=6.1)
+    #if swift(>=5.5)
     @TaskLocal public static var singleton = Singleton()
     #else
     public static let singleton = Singleton()

--- a/Tests/FactoryTests/ParallelTests.swift
+++ b/Tests/FactoryTests/ParallelTests.swift
@@ -90,6 +90,7 @@ struct ParallelTests {
         }
     }
 
+    // Illustrates using container suite trait
     @Suite(.container)
     struct ParallelSuiteTests {
         @Test
@@ -178,7 +179,124 @@ struct ParallelTests {
             #expect(sut3.fooBarBazSingleton.value == "bar")
             #expect(sut1.fooBarBazSingleton.id != sut3.fooBarBazSingleton.id)
         }
+
+        // Illustrates using a custom container test trait
+        @Test(.customContainer)
+        func custom1() {
+            CustomContainer.shared.test.register { MockServiceN(1) }
+
+            let service1 = CustomContainer.shared.test.resolve()
+            #expect(service1.text() == "MockService1")
+        }
+
+        // Illustrates using a custom container test trait with support closure
+        @Test(.customContainer {
+            $0.test.register { MockServiceN(2) }
+        })
+        func custom2() {
+            let service1 = CustomContainer.shared.test.resolve()
+            #expect(service1.text() == "MockService2")
+        }
+
+        // Illustrates using a custom container test trait with support closure
+        @Test(.customContainer {
+            $0.test.register { MockServiceN(3) }
+        })
+        func custom3() {
+            let service1 = CustomContainer.shared.test.resolve()
+            #expect(service1.text() == "MockService3")
+        }
+
+        // Illustrates inheriting the container suite trait from a parent suite
+        @Suite
+        struct ParallelChildSuiteTests {
+            @Test
+            func foo() {
+                Container.shared.with {
+                    $0.fooBarBaz.register { Foo() }
+                    $0.fooBarBazCached.register { Foo() }
+                    $0.fooBarBazSingleton.register { Foo() }
+                }
+
+                let sut1 = TaskLocalUseCase()
+                #expect(sut1.fooBarBaz.value == "foo")
+                #expect(sut1.fooBarBazCached.value == "foo")
+                #expect(sut1.fooBarBazSingleton.value == "foo")
+
+                let sut2 = TaskLocalUseCase()
+                #expect(sut2.fooBarBaz.value == "foo")
+                #expect(sut2.fooBarBazCached.value == "foo")
+                #expect(sut2.fooBarBazSingleton.value == "foo")
+
+                #expect(sut1.fooBarBaz.id != sut2.fooBarBaz.id)
+                #expect(sut1.fooBarBazCached.id == sut2.fooBarBazCached.id)
+                #expect(sut1.fooBarBazSingleton.id == sut2.fooBarBazSingleton.id)
+
+                Container.shared.fooBarBazSingleton.register { Bar() }
+
+                let sut3 = TaskLocalUseCase()
+                #expect(sut3.fooBarBazSingleton.value == "bar")
+                #expect(sut1.fooBarBazSingleton.id != sut3.fooBarBazSingleton.id)
+            }
+
+            @Test
+            func bar() {
+                Container.shared.with {
+                    $0.fooBarBaz.register { Bar() }
+                    $0.fooBarBazCached.register { Bar() }
+                    $0.fooBarBazSingleton.register { Bar() }
+                }
+
+                let sut1 = TaskLocalUseCase()
+                #expect(sut1.fooBarBaz.value == "bar")
+                #expect(sut1.fooBarBazCached.value == "bar")
+                #expect(sut1.fooBarBazSingleton.value == "bar")
+
+                let sut2 = TaskLocalUseCase()
+                #expect(sut2.fooBarBaz.value == "bar")
+                #expect(sut2.fooBarBazCached.value == "bar")
+                #expect(sut2.fooBarBazSingleton.value == "bar")
+
+                #expect(sut1.fooBarBaz.id != sut2.fooBarBaz.id)
+                #expect(sut1.fooBarBazCached.id == sut2.fooBarBazCached.id)
+                #expect(sut1.fooBarBazSingleton.id == sut2.fooBarBazSingleton.id)
+
+                Container.shared.fooBarBazSingleton.register { Foo() }
+
+                let sut3 = TaskLocalUseCase()
+                #expect(sut3.fooBarBazSingleton.value == "foo")
+                #expect(sut1.fooBarBazSingleton.id != sut3.fooBarBazSingleton.id)
+            }
+
+            @Test
+            func baz() {
+                Container.shared.with {
+                    $0.fooBarBaz.register { Baz() }
+                    $0.fooBarBazCached.register { Baz() }
+                    $0.fooBarBazSingleton.register { Baz() }
+                }
+
+                let sut1 = TaskLocalUseCase()
+                #expect(sut1.fooBarBaz.value == "baz")
+                #expect(sut1.fooBarBazCached.value == "baz")
+                #expect(sut1.fooBarBazSingleton.value == "baz")
+
+                let sut2 = TaskLocalUseCase()
+                #expect(sut2.fooBarBaz.value == "baz")
+                #expect(sut2.fooBarBazCached.value == "baz")
+                #expect(sut2.fooBarBazSingleton.value == "baz")
+
+                #expect(sut1.fooBarBaz.id != sut2.fooBarBaz.id)
+                #expect(sut1.fooBarBazCached.id == sut2.fooBarBazCached.id)
+                #expect(sut1.fooBarBazSingleton.id == sut2.fooBarBazSingleton.id)
+
+                Container.shared.fooBarBazSingleton.register { Bar() }
+
+                let sut3 = TaskLocalUseCase()
+                #expect(sut3.fooBarBazSingleton.value == "bar")
+                #expect(sut1.fooBarBazSingleton.id != sut3.fooBarBazSingleton.id)
+            }
+        }
     }
-    
 }
 #endif

--- a/Tests/FactoryTests/ParallelXCTest.swift
+++ b/Tests/FactoryTests/ParallelXCTest.swift
@@ -1,4 +1,4 @@
-#if swift(>=6.1)
+#if swift(>=5.5)
 
 import XCTest
 @testable import Factory


### PR DESCRIPTION
### Docs
I added the docs mostly to the Testing page, but I also slightly adjusted the Container and Readme. I considered the GettingStarted page as well, but then decided to not touch it as this info might be too much for a reader who's only getting familiar with Factory.

### Changes
While writing the docs I found that there are some small things that should be adjusted in the code as well.

#### isRecursive code docs
A child-suite also gets the power of the trait from its parent. Changed the docs and added illustrations to the ParallelTests file

#### TaskLocal is available since Swift 5.5.
While adding TaskLocal to the default Container and to the Singleton scope is primarily to enable test traits, one can still benefit from them without test traits (see docs adjustments). So I changed the `#if swift(>=6.1)` to `#if swift(>=5.5)` since TaskLocals got introduced in 5.5. See https://github.com/swiftlang/swift-evolution/blob/main/proposals/0311-task-locals.md