### PR TITLE
Add FactoryTesting library to Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,10 @@ let package = Package(
             name: "Factory",
             targets: ["Factory"]
         ),
+        .library(
+            name: "FactoryTesting",
+            targets: ["FactoryTesting"]
+        ),
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.


### PR DESCRIPTION
Hello,
I have been using factory for a while and absolutely love it! I have been trying to use it for Unit Testing in SwiftTesting and I am having some problems. I noticed that it isn't a library which is required to be able to import the target, so this Is my small contribution to such a fantastic project!