### PR TITLE
Add testing support for Xcode 16.2 and below

### DIFF
--- a/Package-Testing.swift
+++ b/Package-Testing.swift
@@ -26,7 +26,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.1.0"),
-        .package(url: "https://github.com/swiftlang/swift-testing.git", from: "6.1.0")
+        .package(url: "https://github.com/swiftlang/swift-testing", from: "6.1.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -46,7 +46,7 @@ let package = Package(
         ),
         .testTarget(
             name: "FactoryTests",
-            dependencies: ["Factory", "FactoryTesting"]
+            dependencies: ["Factory", "FactoryTesting", .product(name: "Testing", package: "swift-testing")]
         )
     ],
     swiftLanguageVersions: [

--- a/Package-Testing.swift
+++ b/Package-Testing.swift
@@ -18,10 +18,15 @@ let package = Package(
             name: "Factory",
             targets: ["Factory"]
         ),
+        .library(
+            name: "FactoryTesting",
+            targets: ["FactoryTesting"]
+        ),
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.1.0"),
+        .package(url: "https://github.com/swiftlang/swift-testing.git", from: "6.1.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -31,24 +36,20 @@ let package = Package(
             dependencies: [],
             resources: [.copy("PrivacyInfo.xcprivacy")],
             swiftSettings: [
-                // Enable Swift's strict concurrency checker
-                .unsafeFlags(["-Xfrontend", "-strict-concurrency=complete"], .when(configuration: .debug))
+//                .unsafeFlags(["-Xfrontend", "-strict-concurrency=complete"], .when(configuration: .debug)),
+//                .unsafeFlags(["-enable-library-evolution"], .when(configuration: .release))
             ]
         ),
         .target(
             name: "FactoryTesting",
-            dependencies: ["Factory"]
+            dependencies: ["Factory", .product(name: "Testing", package: "swift-testing")]
         ),
         .testTarget(
             name: "FactoryTests",
-            dependencies: ["Factory", "FactoryTesting"],
-            swiftSettings: [
-                // Enable Swift's strict concurrency checker
-                .unsafeFlags(["-Xfrontend", "-strict-concurrency=complete"], .when(configuration: .debug))
-            ]
+            dependencies: ["Factory", "FactoryTesting"]
         )
     ],
     swiftLanguageVersions: [
-        .version("6")//, .v5
+        .version("6"), .v5
     ]
 )

--- a/Package.resolved
+++ b/Package.resolved
@@ -17,6 +17,24 @@
         "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
         "version" : "1.0.0"
       }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "state" : {
+        "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
+        "version" : "601.0.1"
+      }
+    },
+    {
+      "identity" : "swift-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-testing.git",
+      "state" : {
+        "revision" : "43b6f88e2f2712e0f2a97e6acc75b55f22234299",
+        "version" : "6.1.0"
+      }
     }
   ],
   "version" : 2

--- a/Package.swift
+++ b/Package.swift
@@ -26,6 +26,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.1.0"),
+        .package(url: "https://github.com/swiftlang/swift-testing.git", from: "6.1.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -41,7 +42,7 @@ let package = Package(
         ),
         .target(
             name: "FactoryTesting",
-            dependencies: ["Factory"]
+            dependencies: ["Factory", "Testing"]
         ),
         .testTarget(
             name: "FactoryTests",

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.1.0"),
-        .package(url: "https://github.com/swiftlang/swift-testing.git", from: "6.1.0")
+        .package(url: "https://github.com/swiftlang/swift-testing", from: "6.1.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -42,11 +42,11 @@ let package = Package(
         ),
         .target(
             name: "FactoryTesting",
-            dependencies: ["Factory", "Testing"]
+            dependencies: ["Factory", .product(name: "Testing", package: "swift-testing")]
         ),
         .testTarget(
             name: "FactoryTests",
-            dependencies: ["Factory", "FactoryTesting"]
+            dependencies: ["Factory", "FactoryTesting", .product(name: "Testing", package: "swift-testing")]
         )
     ],
     swiftLanguageVersions: [

--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,30 @@
 
 import PackageDescription
 
+#if swift(<6.0)
+private let importOpenSourceSwiftTesting = true
+#else
+private let importOpenSourceSwiftTesting = false
+#endif
+
+/// Only clone swift-testing from Github when Xcode doesn't support necessary features
+private func getOpenSourceSwiftTestingPackageDependency() -> [Package.Dependency] {
+    guard importOpenSourceSwiftTesting else {
+        return []
+    }
+    
+    return [.package(url: "https://github.com/swiftlang/swift-testing", from: "6.1.0")]
+}
+
+/// Only link swift-testing from Github when Xcode doesn't support necessary features
+private func getOpenSourceSwiftTestingPackageTarget() -> [Target.Dependency] {
+    guard importOpenSourceSwiftTesting else {
+        return []
+    }
+    
+    return [.product(name: "Testing", package: "swift-testing")]
+}
+
 let package = Package(
     name: "Factory",
     platforms: [
@@ -26,8 +50,9 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.1.0"),
-        .package(url: "https://github.com/swiftlang/swift-testing", from: "6.1.0")
-    ],
+        
+        // Only clone swift-testing if required
+    ] + getOpenSourceSwiftTestingPackageDependency(),
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
@@ -42,11 +67,15 @@ let package = Package(
         ),
         .target(
             name: "FactoryTesting",
-            dependencies: ["Factory", .product(name: "Testing", package: "swift-testing")]
+            
+            // Only link swift-testing if required
+            dependencies: ["Factory"] + getOpenSourceSwiftTestingPackageTarget()
         ),
         .testTarget(
             name: "FactoryTests",
-            dependencies: ["Factory", "FactoryTesting", .product(name: "Testing", package: "swift-testing")]
+            
+            // Only link swift-testing if required
+            dependencies: ["Factory", "FactoryTesting"] + getOpenSourceSwiftTestingPackageTarget()
         )
     ],
     swiftLanguageVersions: [


### PR DESCRIPTION
FactoryTesting uses a feature of SwiftTesting only available in Xcode 16.3 and newer. To enable compatibility with previous Xcode versions, I added the open source version of SwiftTesting to the package manifest. To keep sizes down, I made it only clone on versions with the compiler as 6.0 or lower.