### PR TITLE
Revert back minimum swift version to 6.1 in ContainerTrait

### DIFF
--- a/Sources/FactoryTesting/ContainerTrait.swift
+++ b/Sources/FactoryTesting/ContainerTrait.swift
@@ -25,7 +25,7 @@
 //
 
 #if DEBUG
-#if swift(>=5.5)
+#if swift(>=6.1)
 
 import Factory
 import Testing


### PR DESCRIPTION
This PR revert the minimum required swift version to build `ContainerTrait` to 6.1. This is due the `TestScoping` protocol being only available to Swift 6.1+. `TestTrait` and `SuiteTrait` are also available in Swift 6.0 instead.

See also: 
https://swiftpackageindex.com/builds/22D01235-AA11-44C3-BC91-EBF00D21700A
https://swiftpackageindex.com/builds/3245DEE0-DB0E-4AD7-8C5B-5C9F1C866671
https://swiftpackageindex.com/builds/C4E68254-31B9-4C4B-A308-75C08B805D4B

<img width="968" alt="Screenshot 2025-05-06 at 11 51 53" src="https://github.com/user-attachments/assets/90134d9f-6ebb-47b4-b0d6-2308aef3bbb8" />
