### PR TITLE
[FIX] Make symlinks relative in `develop` branch

### DIFF
--- a/Sources/FactoryKit/FactoryKit/Aliases.swift
+++ b/Sources/FactoryKit/FactoryKit/Aliases.swift
@@ -1,0 +1,1 @@
+../../Factory/Factory/Aliases.swift

--- a/Sources/FactoryKit/FactoryKit/Containers.swift
+++ b/Sources/FactoryKit/FactoryKit/Containers.swift
@@ -1,1 +1,1 @@
-/Users/michael/Dropbox/Projects/iOS/OSS/Factory/Factory/Sources/Factory/Factory/Containers.swift
+../../Factory/Factory/Containers.swift

--- a/Sources/FactoryKit/FactoryKit/Contexts.swift
+++ b/Sources/FactoryKit/FactoryKit/Contexts.swift
@@ -1,1 +1,1 @@
-/Users/michael/Dropbox/Projects/iOS/OSS/Factory/Factory/Sources/Factory/Factory/Contexts.swift
+../../Factory/Factory/Contexts.swift

--- a/Sources/FactoryKit/FactoryKit/Factory.swift
+++ b/Sources/FactoryKit/FactoryKit/Factory.swift
@@ -1,1 +1,1 @@
-/Users/michael/Dropbox/Projects/iOS/OSS/Factory/Factory/Sources/Factory/Factory/Factory.swift
+../../Factory/Factory/Factory.swift

--- a/Sources/FactoryKit/FactoryKit/Globals.swift
+++ b/Sources/FactoryKit/FactoryKit/Globals.swift
@@ -1,1 +1,1 @@
-/Users/michael/Dropbox/Projects/iOS/OSS/Factory/Factory/Sources/Factory/Factory/Globals.swift
+../../Factory/Factory/Globals.swift

--- a/Sources/FactoryKit/FactoryKit/Injections.swift
+++ b/Sources/FactoryKit/FactoryKit/Injections.swift
@@ -1,1 +1,1 @@
-/Users/michael/Dropbox/Projects/iOS/OSS/Factory/Factory/Sources/Factory/Factory/Injections.swift
+../../Factory/Factory/Injections.swift

--- a/Sources/FactoryKit/FactoryKit/Key.swift
+++ b/Sources/FactoryKit/FactoryKit/Key.swift
@@ -1,1 +1,1 @@
-/Users/michael/Dropbox/Projects/iOS/OSS/Factory/Factory/Sources/Factory/Factory/Key.swift
+../../Factory/Factory/Key.swift

--- a/Sources/FactoryKit/FactoryKit/Locking.swift
+++ b/Sources/FactoryKit/FactoryKit/Locking.swift
@@ -1,1 +1,1 @@
-/Users/michael/Dropbox/Projects/iOS/OSS/Factory/Factory/Sources/Factory/Factory/Locking.swift
+../../Factory/Factory/Locking.swift

--- a/Sources/FactoryKit/FactoryKit/Modifiers.swift
+++ b/Sources/FactoryKit/FactoryKit/Modifiers.swift
@@ -1,1 +1,1 @@
-/Users/michael/Dropbox/Projects/iOS/OSS/Factory/Factory/Sources/Factory/Factory/Modifiers.swift
+../../Factory/Factory/Modifiers.swift

--- a/Sources/FactoryKit/FactoryKit/Registrations.swift
+++ b/Sources/FactoryKit/FactoryKit/Registrations.swift
@@ -1,1 +1,1 @@
-/Users/michael/Dropbox/Projects/iOS/OSS/Factory/Factory/Sources/Factory/Factory/Registrations.swift
+../../Factory/Factory/Registrations.swift

--- a/Sources/FactoryKit/FactoryKit/Resolutions.swift
+++ b/Sources/FactoryKit/FactoryKit/Resolutions.swift
@@ -1,1 +1,1 @@
-/Users/michael/Dropbox/Projects/iOS/OSS/Factory/Factory/Sources/Factory/Factory/Resolutions.swift
+../../Factory/Factory/Resolutions.swift

--- a/Sources/FactoryKit/FactoryKit/Resolver.swift
+++ b/Sources/FactoryKit/FactoryKit/Resolver.swift
@@ -1,1 +1,1 @@
-/Users/michael/Dropbox/Projects/iOS/OSS/Factory/Factory/Sources/Factory/Factory/Resolver.swift
+../../Factory/Factory/Resolver.swift

--- a/Sources/FactoryKit/FactoryKit/Scopes.swift
+++ b/Sources/FactoryKit/FactoryKit/Scopes.swift
@@ -1,1 +1,1 @@
-/Users/michael/Dropbox/Projects/iOS/OSS/Factory/Factory/Sources/Factory/Factory/Scopes.swift
+../../Factory/Factory/Scopes.swift

--- a/generate-symlinks.swift
+++ b/generate-symlinks.swift
@@ -14,6 +14,22 @@ let fileManager = FileManager.default
 let sourceURL = URL(fileURLWithPath: sourceDir)
 let linkURL = URL(fileURLWithPath: linkDir)
 
+func relativePath(from base: URL, to target: URL) -> String {
+    let baseComponents = base.standardized.pathComponents
+    let targetComponents = target.standardized.pathComponents
+
+    var index = 0
+    while index < baseComponents.count && index < targetComponents.count &&
+          baseComponents[index] == targetComponents[index] {
+        index += 1
+    }
+
+    // `up`: how many levels we need to move upwards in the directory
+    let up = Array(repeating: "..", count: baseComponents.count - index)
+    let down = targetComponents[index...]
+    return (up + down).joined(separator: "/")
+}
+
 do {
     // Ensure symlink target directory exists
     try? fileManager.removeItem(at: linkURL) // Clean slate
@@ -27,8 +43,10 @@ do {
         let sourceFile = sourceURL.appendingPathComponent(file)
         let linkFile = linkURL.appendingPathComponent(file)
 
-        try fileManager.createSymbolicLink(at: linkFile, withDestinationURL: sourceFile)
-        print("Linked \(file)")
+        let relativeTargetPath = relativePath(from: linkFile.deletingLastPathComponent(), to: sourceFile)
+
+        try fileManager.createSymbolicLink(atPath: linkFile.path, withDestinationPath: relativeTargetPath)
+        print("Linked \(file) → \(relativeTargetPath)")
     }
 
     print("✅ Symlinks created in \(linkDir)")


### PR DESCRIPTION
In current `develop` branch the symlinks are full path rather than relative.
This PR fixes that

#### More context
I was trying to integrate `FactoryKit` (2.5.0 https://github.com/hmlongco/Factory/discussions/295)  using `tuist` after fixing hardcoded path I still can't run `tuist generate`, it throws error
`File not found at project-path/Tuist/.build/checkouts/Factory/Sources/FactoryKit/FactoryKit/Containers.swift`

I will spend more time to fix it but looks like [tuist](https://github.com/tuist/tuist) issue, nothing related to `Factory`