### PR TITLE
Fix unique scope resolution issue on container with non-unique default scope

### DIFF
--- a/Sources/Factory/Factory/Scopes.swift
+++ b/Sources/Factory/Factory/Scopes.swift
@@ -193,8 +193,18 @@ extension Scope {
 
     /// A reference to the default unique scope.
     ///
-    /// If no scope cache is specified then Factory is running in unique mode.
-    public static let unique: Scope? = nil
+    /// If no scope cache is specified then Factory is running in unique mode.    
+    public static let unique = Unique()
+    
+    /// Defines the unique scope. A new instance of a given type will be returned on every resolution cycle.
+    public final class Unique: Scope, @unchecked Sendable  {
+        public override init() {
+            super.init()
+        }
+        internal override func resolve<T>(using cache: Cache, key: FactoryKey, ttl: TimeInterval?, factory: () -> T) -> T {
+            factory()
+        }
+    }
 
 }
 

--- a/Sources/FactoryKit/FactoryKit/Scopes.swift
+++ b/Sources/FactoryKit/FactoryKit/Scopes.swift
@@ -194,7 +194,17 @@ extension Scope {
     /// A reference to the default unique scope.
     ///
     /// If no scope cache is specified then Factory is running in unique mode.
-    public static let unique: Scope? = nil
+    public static let unique = Unique()
+    
+    /// Defines the unique scope. A new instance of a given type will be returned on every resolution cycle.
+    public final class Unique: Scope, @unchecked Sendable  {
+        public override init() {
+            super.init()
+        }
+        internal override func resolve<T>(using cache: Cache, key: FactoryKey, ttl: TimeInterval?, factory: () -> T) -> T {
+            factory()
+        }
+    }
 
 }
 

--- a/Tests/FactoryTests/FactoryScopeTests.swift
+++ b/Tests/FactoryTests/FactoryScopeTests.swift
@@ -398,6 +398,13 @@ final class FactoryScopeTests: XCTestCase {
         let service3 = Container.shared.singletonService()
         XCTAssertTrue(service2.id != service3.id)
     }
+    
+    func testUniqueResolutionOnCachedContainer() throws {
+        let service1 = CachedContainer.shared.uniqueService()
+        let service2 = CachedContainer.shared.uniqueService()
+        XCTAssertTrue(service1 !== service2)
+        XCTAssertTrue(service1.id != service2.id)
+    }
 
 }
 
@@ -429,3 +436,14 @@ fileprivate final class SecondSingletonContainer: SharedContainer, AutoRegisteri
     let manager = ContainerManager()
 }
 
+
+fileprivate final class CachedContainer: SharedContainer, AutoRegistering {
+    static let shared: CachedContainer = CachedContainer()
+    let manager: ContainerManager = ContainerManager()
+    func autoRegister() {
+        manager.defaultScope = .cached
+    }
+    var uniqueService: Factory<MyService> {
+        self { MyService() }.unique
+    }
+}


### PR DESCRIPTION
See #306 

Due to the `.unique` scope being changed to `nil` in Factory 2.5.x, resolution of a dependency with `.unique` scope set on the factory inside a Container with default scope being != `.unique` was using the default scope instead of the specific one (coalesce evaluating the default):

https://github.com/hmlongco/Factory/blob/56129530a97d89d03f610685d348d333af4989bb/Sources/FactoryKit/FactoryKit/Registrations.swift#L117