### PR TITLE
Fix for registering test containers using swift test command.

### DIFF
--- a/Sources/Factory/Factory/Contexts.swift
+++ b/Sources/Factory/Factory/Contexts.swift
@@ -60,6 +60,9 @@ public struct FactoryContext {
         if ProcessInfo.processInfo.processName.contains("xctest") {
             testing = true
         }
+        if ProcessInfo.processInfo.processName.contains("swiftpm-testing-helper") {
+            testing = true
+        }
         return testing
     }()
     /// Proxy check for application running in simulator.

--- a/Sources/FactoryKit/FactoryKit/Contexts.swift
+++ b/Sources/FactoryKit/FactoryKit/Contexts.swift
@@ -60,6 +60,9 @@ public struct FactoryContext {
         if ProcessInfo.processInfo.processName.contains("xctest") {
             testing = true
         }
+        if ProcessInfo.processInfo.processName.contains("swiftpm-testing-helper") {
+            testing = true
+        }
         return testing
     }()
     /// Proxy check for application running in simulator.


### PR DESCRIPTION
**Description:**
When running tests with swift test, the process name is set to swiftpm-testing-helper.
Currently, the isTest check does not detect this case, which causes test-specific logic to fail under SwiftPM.
This PR updates the isTest check to also recognize swiftpm-testing-helper as a valid test process.

**Changes:**
Added process name check for swiftpm-testing-helper in isTest.

**Why:**
Ensures isTest works consistently when running tests both in Xcode and via Swift Package Manager.

**Fixes:**
#94