### PR TITLE
Fix documentation Referencing-Other-Containers section

### DIFF
--- a/Sources/FactoryKit/FactoryKit.docc/Basics/Containers.md
+++ b/Sources/FactoryKit/FactoryKit.docc/Basics/Containers.md
@@ -127,7 +127,7 @@ Don't forget that if need be you can reach across containers simply by specifyin
 
 ```swift
 extension PaymentsContainer {
-    let anotherService = Factory<AnotherService> { 
+    var anotherService: Factory<AnotherService> { 
         self { AnotherService(using: Container.shared.optionalService()) }
     }
 }


### PR DESCRIPTION
Description:
When I was digging up the documentation of Factory, I noticed that there is a problem with a block of code in [this section](https://hmlongco.github.io/Factory/documentation/factorykit/containers/#Referencing-Other-Containers). I believe that my change reflects the Swift code the author meant to write in the first place.

Changes:
transforms `PaymentsContainer.anotherService` into a computed var instead of a store property in an extension.