### PR TITLE
Add a decorator which tells you whether the instance was cached or not

### DIFF
--- a/Sources/Factory/Factory/Modifiers.swift
+++ b/Sources/Factory/Factory/Modifiers.swift
@@ -157,6 +157,29 @@ extension FactoryModifying {
         registration.decorator(decorator)
         return self
     }
+    
+    /// Adds a factory-specific decorator. The decorator will *always* be called with the resolved dependency
+    /// for further examination or manipulation.
+    ///
+    /// This includes previously created items that have been cached by a scope. However, this type of decorator
+    /// provides a boolean to inform you about whether the provided instance was pulled from the cache.  This
+    /// can help you decide whether some operations are necessary to handle the newly created object or not.
+    /// ```swift
+    /// var decoratedService: Factory<ParentChildService> {
+    ///    self { ParentChildService() }
+    ///        .decorated { instance, wasCached
+    ///            if !wasCached {
+    ///                $0.child.parent = $0
+    ///            }
+    ///        }
+    /// }
+    /// ```
+    /// As shown, decorator can come in handy when you need to perform some operation or manipulation after the fact.
+    @discardableResult
+    public func decorator(_ decorator: @escaping @Sendable (_ instance: T, _ wasCached: Bool) -> Void) -> Self {
+        registration.decorator(decorator)
+        return self
+    }
 
 }
 

--- a/Sources/Factory/Factory/Registrations.swift
+++ b/Sources/Factory/Factory/Registrations.swift
@@ -114,10 +114,15 @@ public struct FactoryRegistration<P,T>: Sendable {
 
         globalGraphResolutionDepth += 1
         let instance: T
+        var wasCached = true
         if let scope = options?.scope ?? manager.defaultScope {
             let parameterizedKey = options?.scopeOnParameters == true ? key.parameterized(parameters) : key
-            instance = scope.resolve(using: manager.cache, key: parameterizedKey, ttl: options?.ttl, factory: { current(parameters) }) }
-        else {
+            instance = scope.resolve(using: manager.cache, key: parameterizedKey, ttl: options?.ttl, factory: {
+                wasCached = false
+                return current(parameters)
+            })
+        } else {
+            wasCached = false
             instance = current(parameters)
         }
         globalGraphResolutionDepth -= 1
@@ -150,6 +155,9 @@ public struct FactoryRegistration<P,T>: Sendable {
 
         if let decorator = options?.decorator as? (T) -> Void {
             decorator(instance)
+        }
+        if let decorator = options?.decorator as? (T, Bool) -> Void {
+            decorator(instance, wasCached)
         }
         if let decorator = manager.decorator {
             decorator(instance)
@@ -223,6 +231,12 @@ public struct FactoryRegistration<P,T>: Sendable {
 
     /// Registers a new decorator.
     internal func decorator(_ decorator: @escaping (T) -> Void) {
+        options { options in
+            options.decorator = decorator
+        }
+    }
+    
+    internal func decorator(_ decorator: @escaping (T, Bool) -> Void) {
         options { options in
             options.decorator = decorator
         }

--- a/Sources/FactoryKit/FactoryKit/Modifiers.swift
+++ b/Sources/FactoryKit/FactoryKit/Modifiers.swift
@@ -157,6 +157,29 @@ extension FactoryModifying {
         registration.decorator(decorator)
         return self
     }
+    
+    /// Adds a factory-specific decorator. The decorator will *always* be called with the resolved dependency
+    /// for further examination or manipulation.
+    ///
+    /// This includes previously created items that have been cached by a scope. However, this type of decorator
+    /// provides a boolean to inform you about whether the provided instance was pulled from the cache.  This
+    /// can help you decide whether some operations are necessary to handle the newly created object or not.
+    /// ```swift
+    /// var decoratedService: Factory<ParentChildService> {
+    ///    self { ParentChildService() }
+    ///        .decorated { instance, wasCached
+    ///            if !wasCached {
+    ///                $0.child.parent = $0
+    ///            }
+    ///        }
+    /// }
+    /// ```
+    /// As shown, decorator can come in handy when you need to perform some operation or manipulation after the fact.
+    @discardableResult
+    public func decorator(_ decorator: @escaping @Sendable (_ instance: T, _ wasCached: Bool) -> Void) -> Self {
+        registration.decorator(decorator)
+        return self
+    }
 
 }
 

--- a/Sources/FactoryKit/FactoryKit/Registrations.swift
+++ b/Sources/FactoryKit/FactoryKit/Registrations.swift
@@ -114,10 +114,15 @@ public struct FactoryRegistration<P,T>: Sendable {
 
         globalGraphResolutionDepth += 1
         let instance: T
+        var wasCached = true
         if let scope = options?.scope ?? manager.defaultScope {
             let parameterizedKey = options?.scopeOnParameters == true ? key.parameterized(parameters) : key
-            instance = scope.resolve(using: manager.cache, key: parameterizedKey, ttl: options?.ttl, factory: { current(parameters) }) }
-        else {
+            instance = scope.resolve(using: manager.cache, key: parameterizedKey, ttl: options?.ttl, factory: {
+                wasCached = false
+                return current(parameters)
+            })
+        } else {
+            wasCached = false
             instance = current(parameters)
         }
         globalGraphResolutionDepth -= 1
@@ -150,6 +155,9 @@ public struct FactoryRegistration<P,T>: Sendable {
 
         if let decorator = options?.decorator as? (T) -> Void {
             decorator(instance)
+        }
+        if let decorator = options?.decorator as? (T, Bool) -> Void {
+            decorator(instance, wasCached)
         }
         if let decorator = manager.decorator {
             decorator(instance)
@@ -223,6 +231,12 @@ public struct FactoryRegistration<P,T>: Sendable {
 
     /// Registers a new decorator.
     internal func decorator(_ decorator: @escaping (T) -> Void) {
+        options { options in
+            options.decorator = decorator
+        }
+    }
+    
+    internal func decorator(_ decorator: @escaping (T, Bool) -> Void) {
         options { options in
             options.decorator = decorator
         }

--- a/Tests/FactoryTests/FactoryCoreTests.swift
+++ b/Tests/FactoryTests/FactoryCoreTests.swift
@@ -152,6 +152,16 @@ final class FactoryCoreTests: XCTestCase {
         let _ = CustomContainer.shared.decorated()
         XCTAssertEqual(CustomContainer.shared.count, 4)
     }
+    
+    func testFactoryWasCachedDecorators() {
+        XCTAssertEqual(CustomContainer.shared.count, 0)
+        let _ = CustomContainer.shared.decoratedWasCached()
+        XCTAssertEqual(CustomContainer.shared.count, 2)
+        let _ = CustomContainer.shared.decoratedWasCached()
+        XCTAssertEqual(CustomContainer.shared.count, 2)
+        let _ = CustomContainer.shared.decoratedWasCached()
+        XCTAssertEqual(CustomContainer.shared.count, 2)
+    }
 
     func testFactoryOnce() {
         XCTAssertEqual(CustomContainer.shared.count, 0)

--- a/Tests/FactoryTests/MockServices.swift
+++ b/Tests/FactoryTests/MockServices.swift
@@ -212,6 +212,17 @@ final class CustomContainer: SharedContainer, AutoRegistering {
             self.count += 1
         }
     }
+    var decoratedWasCached: Factory<MyService> {
+        self {
+            MyService()
+        }
+        .scope(.cached)
+        .decorator { _, wasCached in
+            if !wasCached {
+                self.count += 1
+            }
+        }
+    }
     var once: Factory<MyServiceType> {
         self {
             MyService()


### PR DESCRIPTION
At Dropbox, we've been adopting FactoryKit but have run into a few things we would love to see improved to add functionality.  One such thing is the ability to easily decorate a factory registration and run the code only when a new instance is created.

# Use Case

Our use case is like this:
1. We have an object, A, which is created with scope `.cached` so it's one-per-container.
2. We need to do a bunch of stuff after that object is created, but it could have circular references to A's factory in some cases.  If that work is done within the factory it infinite loops.
3. We put the work in the decorator instead!  This is great because it means that any accesses to A's factory resolve to the cached version of A.
4. However, the decorator _always_ runs, as is noted in the documentation.  This is not desirable because we have some work we only want to do once when the object is created, not every time it's accessed.

# Workaround
We've currently been working around this problem in a hacky way like so:
```swift
private var exampleMutex: Factory<Bool> { self {
        false
}.cached }

var exampleFactory: Factory<Example> { self {
    Example()
}.cached
.decorator { instance in
    if self.exampleMutex.resolve() == false {
        self.exampleMutex.register { true }
        self.someObject.resolve().setExample(instance)
    }
}}
```

We're heavily relying on the global lock to make this safe, and we don't like how it reads nor how we feel like we're abusing a registration to do something that's otherwise pretty simple to do inside the library.

# Proposed Solution
```swift
var exampleFactory: Factory<Example> { self {
    Example()
}.cached
.decorator { instance, wasCached in
    if !wasCached {
        self.someObject.resolve().setExample(instance)
    }
}}
```
We instead allow a decorator to be added with a second parameter, a boolean which tells you if the object was read from cache when resolved.

## Alternatives considered
I looked around at `.once()` but was unable to deduce what it does well enough based on existing documentation and reading through the source code.  It seems like the kind of thing which _might_ help us here but I don't understand what it does.  Based off the tests it seems it does not do what we want.

I considered making a decorator which would be called selectively rather than providing the boolean, but based off the fact that this didn't already exist, it seems like you prefer that decorators are called every time.  If you're amenable to a decorator which is instead selectively called based on cache status, I'm more than happy to make that change.  I also considered whether to change the name of the `.decorator` call to something else, like `.newInstanceDecorator` or something similar, but with the bool property, it didn't feel necessary.  It would be necessary to differentiate a decorator which is selectively called though and would welcome your naming suggestions there.

I also considered whether to inverse the boolean, to something like `isNewInstance`, but no name felt quite as easy to understand as `wasCached`.  I'm open to other options here as well, just let us know what makes the most sense for FactoryKit.

---
Thanks for considering my PR, please feel free to tear it apart with comments, as it is my first contribution.  I won't take it personally.