### PR TITLE
Minor performance improvement for LazyInjected

### DIFF
--- a/Sources/Factory/Factory/Registrations.swift
+++ b/Sources/Factory/Factory/Registrations.swift
@@ -247,6 +247,7 @@ public struct FactoryRegistration<P,T>: Sendable {
     ///   - options: Reset option: .all, .registration, .scope, .none
     ///   - id: ID of item to remove from the appropriate cache.
     internal func reset(options: FactoryResetOptions) {
+        guard options != .none else { return }
         defer { globalRecursiveLock.unlock()  }
         globalRecursiveLock.lock()
         let manager = container.manager

--- a/Sources/FactoryKit/FactoryKit/Registrations.swift
+++ b/Sources/FactoryKit/FactoryKit/Registrations.swift
@@ -247,6 +247,7 @@ public struct FactoryRegistration<P,T>: Sendable {
     ///   - options: Reset option: .all, .registration, .scope, .none
     ///   - id: ID of item to remove from the appropriate cache.
     internal func reset(options: FactoryResetOptions) {
+        guard options != .none else { return }
         defer { globalRecursiveLock.unlock()  }
         globalRecursiveLock.lock()
         let manager = container.manager


### PR DESCRIPTION
In a project where we are heavily using FactoryKit I noticed an issue in combination with Swift Concurrency.

One class that we are accessing through a factory has a slow `init` and due to the usage of the `globalRecursiveLock` it can easily block all cooperative queues when many instances are resolved in async contexts leading to thread contention. You can see this in the screenshots.

Ultimately, we need to refactor our code and move the initialization out of the `init`. But this PR is a very minor performance improvement with `@LazyInjected`. It always calls the `reset(options:)` function when initializing with `options: .none`. So at least here we can skip the lock. In the end it still needs the lock when resolving the dependency, but at least it's only locking once instead of twice then.

<img width="586" height="1250" alt="screenshot1" src="https://github.com/user-attachments/assets/457a3b7b-b59f-41f6-a3f1-4095b1d210c7" />
<img width="578" height="1263" alt="screenshot2" src="https://github.com/user-attachments/assets/1f1ceb95-6171-42d6-a8eb-feec08fa0f3f" />