### PR TITLE
Typename resolving optimized

### DIFF
--- a/Sources/Factory/Factory/Key.swift
+++ b/Sources/Factory/Factory/Key.swift
@@ -104,7 +104,7 @@ private func globalIdentifier(for type: Any.Type) -> ObjectIdentifier {
             return knownID
         }
         // this is what we're bypassing. extremely slow runtime function.
-        let name = String(reflecting: type)
+        let name = _typeName(type, qualified: true)
         // magic happens here, if name is already known then get original key for it
         let id = globalNameToIdentifierTable[name, default: requestedTypeID]
         // and save it so we don't have to do this again

--- a/Sources/FactoryKit/FactoryKit/Key.swift
+++ b/Sources/FactoryKit/FactoryKit/Key.swift
@@ -104,7 +104,7 @@ private func globalIdentifier(for type: Any.Type) -> ObjectIdentifier {
             return knownID
         }
         // this is what we're bypassing. extremely slow runtime function.
-        let name = String(reflecting: type)
+        let name = _typeName(type, qualified: true)
         // magic happens here, if name is already known then get original key for it
         let id = globalNameToIdentifierTable[name, default: requestedTypeID]
         // and save it so we don't have to do this again


### PR DESCRIPTION
There is no need to use heavy `String(reflecting:)`, there is much faster alternative.

But internally, `String(reflecting:)` called on class-type eventually calls [`_typeName(:qualified:)` function](https://github.com/swiftlang/swift/blob/main/stdlib/public/core/OutputStream.swift#L308C18-L308C58) with `qualified: true`.

Full call-stack:

- [`String(reflecting:)`](https://github.com/swiftlang/swift/blob/bd554ba524968bb4f10ec0016ce8adca85c268b6/stdlib/public/core/Mirror.swift#L773C5-L773C25)
- [`_debugPrint_unlocked`](https://github.com/swiftlang/swift/blob/bd554ba524968bb4f10ec0016ce8adca85c268b6/stdlib/public/core/OutputStream.swift#L476). Because Any.Type does not conform any of checked protocols.
- [`_adHocPrint_unlocked`](https://github.com/swiftlang/swift/blob/bd554ba524968bb4f10ec0016ce8adca85c268b6/stdlib/public/core/OutputStream.swift#L389)
- [`_adHocPrint_unlocked.printTypeName`](https://github.com/swiftlang/swift/blob/bd554ba524968bb4f10ec0016ce8adca85c268b6/stdlib/public/core/OutputStream.swift#L308)

@hmlongco Michael, I'd love your suggestions on how to edit comments for `globalIdentifier` function.