### PR TITLE
Replace `#if DEBUG` with runtime checks for context registration and resolution

### DIFF
--- a/Sources/FactoryKit/FactoryKit/Modifiers.swift
+++ b/Sources/FactoryKit/FactoryKit/Modifiers.swift
@@ -175,9 +175,9 @@ extension FactoryModifying {
             case .arg, .args, .device, .simulator:
                 registration.context(context, key: registration.key, factory: factory)
             default:
-                #if DEBUG
-                registration.context(context, key: registration.key, factory: factory)
-                #endif
+                if FactoryContext.current.isDebug {
+                    registration.context(context, key: registration.key, factory: factory)
+                }
                 break
             }
         }

--- a/Sources/FactoryKit/FactoryKit/Registrations.swift
+++ b/Sources/FactoryKit/FactoryKit/Registrations.swift
@@ -341,25 +341,25 @@ extension FactoryOptions {
             }
         }
         if let contexts = contexts, !contexts.isEmpty {
-            #if DEBUG
-            if FactoryContext.current.isPreview, let found = contexts["preview"] {
-                return found
+            if FactoryContext.current.isDebug {
+                if FactoryContext.current.isPreview, let found = contexts["preview"] {
+                    return found
+                }
+                if FactoryContext.current.isTest, let found = contexts["test"] {
+                    return found
+                }
             }
-            if FactoryContext.current.isTest, let found = contexts["test"] {
-                return found
-            }
-            #endif
             if FactoryContext.current.isSimulator, let found = contexts["simulator"] {
                 return found
             }
             if !FactoryContext.current.isSimulator, let found = contexts["device"] {
                 return found
             }
-            #if DEBUG
-            if let found = contexts["debug"] {
-                return found
+            if FactoryContext.current.isDebug {
+                if let found = contexts["debug"] {
+                    return found
+                }
             }
-            #endif
         }
         return nil
     }


### PR DESCRIPTION
SPM does not propagate the `DEBUG` compilation condition to package dependencies when Xcode builds previews. This causes `.onPreview`, `.onTest`, and `.onDebug` context factories to silently fail because both the registration path (Modifiers.swift) and resolution path (Registrations.swift) are gated behind `#if DEBUG`, which gets stripped at compile time in SPM packages.

This replaces those compile-time guards with runtime checks using `FactoryContext.current.isDebug`, which correctly detects debug builds at runtime. The behavior is preserved: preview/test/debug contexts are still only active in debug environments, but now work correctly when Factory is consumed as an SPM dependency.