### PR TITLE
Fix .onPreview/.onTest not working in Xcode previews

### DIFF
--- a/Sources/FactoryKit/FactoryKit/Modifiers.swift
+++ b/Sources/FactoryKit/FactoryKit/Modifiers.swift
@@ -175,9 +175,7 @@ extension FactoryModifying {
             case .arg, .args, .device, .simulator:
                 registration.context(context, key: registration.key, factory: factory)
             default:
-                #if DEBUG
                 registration.context(context, key: registration.key, factory: factory)
-                #endif
                 break
             }
         }

--- a/Sources/FactoryKit/FactoryKit/Resolver.swift
+++ b/Sources/FactoryKit/FactoryKit/Resolver.swift
@@ -69,6 +69,8 @@ extension Resolving {
             let key = FactoryKey(type: T.self, key: globalResolverKey)
             if let factory = manager.registrations[key] as? TypedFactory<Void,T> {
                 return Factory(FactoryRegistration<Void,T>(key: globalResolverKey, container: self, factory: factory.factory))
+            } else if let factory = manager.registrations[key]?.untypedFactory as? @Sendable (Void) -> T {
+                return Factory(FactoryRegistration<Void,T>(key: globalResolverKey, container: self, factory: factory))
             }
             // otherwise return nil
             return nil


### PR DESCRIPTION
`.onPreview` and `.onTest` context factories silently fail in Xcode previews. The mock is registered and found, but never used — the default factory runs instead (often `fatalError()`), crashing the preview.

**Cause:** Xcode previews dynamically recompile and inject code, creating duplicate `TypedFactory<P,T>` types across module boundaries. The `as? TypedFactory<P,T>` cast returns `nil` even when both sides are `TypedFactory<(), BillingUI>` — same generic parameters, different runtime type identity.

### Fix

Add a structural function-type cast fallback. When the nominal `TypedFactory<P,T>` cast fails, cast the underlying closure directly via `@Sendable (P) -> T`. Function types use structural typing in
  Swift, which is immune to the compilation-unit identity mismatch.

  - **`Registrations.swift`** — `AnyFactory` exposes `untypedFactory: Any`. `resolve()` falls back to casting the closure when the struct cast fails. Removed `#if DEBUG` from `isPreview`/`isTest` in
  `factoryForCurrentContext()`.
  - **`Resolver.swift`** — Same fallback for the global resolver path.
  - **`Modifiers.swift`** — Removed `#if DEBUG` from context registration `default:` case.

  The normal (non-preview) path is unchanged — the nominal cast succeeds first and the fallback is never reached.

  ### Why remove `#if DEBUG` from preview/test gates

  `isPreview` and `isTest` are `false` in release, so context factories never resolve outside debug builds. User code already wraps `.onPreview`/`.onTest` in `#if DEBUG`. The `.onDebug` context retains its `#if DEBUG` guard.