### PR TITLE
fix: swift testing compiler mode check

### DIFF
--- a/Sources/FactoryTesting/ContainerTrait.swift
+++ b/Sources/FactoryTesting/ContainerTrait.swift
@@ -25,7 +25,7 @@
 //
 
 #if DEBUG
-#if swift(>=6.1)
+#if compiler(>=6.1)
 
 #if canImport(FactoryKit)
 import FactoryKit


### PR DESCRIPTION
### Issue

Swift testing is flagged as swift 6 and 6.1, but this seems to be the compiler version because you're able to use swift testing in a Swift 5 configured project/package. 

The `#if swift(>=6.1)` in the original `FactoryTesting` trait meant you could use FactoryKit with a swift 5 project with swift testing. The swift tests would build fine with `@Suite(.container)` but the trait would never override the singleton under the `@TaskLocal` resulting in race conditions, missed registrations, etc. 

Some research lead to https://github.com/swiftlang/swift-testing/blob/66c32ae6c4f87b88c96cd6f16e6e92538177617e/Sources/Testing/Traits/Trait.swift#L57 where the availability of the trait object is noted as:

```swift
  /// @Metadata {
  ///   @Available(Swift, introduced: 6.1)
  ///   @Available(Xcode, introduced: 16.3)
  /// }
```

I've tested this on my project and it seems to work as expected.