### PR TITLE
Add support for Swift's InternalImportsByDefault upcoming feature #3606

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -60,6 +60,7 @@ let package = Package(
 
 enum FactorySwiftSetting {
     static let common: [SwiftSetting] = [
-        .enableExperimentalFeature("StrictConcurrency")
+        .enableExperimentalFeature("StrictConcurrency"),
+        .enableUpcomingFeature("InternalImportsByDefault"),
     ]
 }

--- a/Sources/FactoryKit/FactoryKit/Containers.swift
+++ b/Sources/FactoryKit/FactoryKit/Containers.swift
@@ -24,10 +24,10 @@
 // THE SOFTWARE.
 //
 
-import Foundation
+internal import Foundation
 
 #if canImport(SwiftUI)
-import SwiftUI
+public import SwiftUI
 #endif
 
 // MARK: - Container

--- a/Sources/FactoryKit/FactoryKit/Contexts.swift
+++ b/Sources/FactoryKit/FactoryKit/Contexts.swift
@@ -24,7 +24,7 @@
 // THE SOFTWARE.
 //
 
-import Foundation
+internal import Foundation
 
 /// Context types available for special purpose factory registrations.
 public enum FactoryContextType: Equatable {

--- a/Sources/FactoryKit/FactoryKit/Dependency.swift
+++ b/Sources/FactoryKit/FactoryKit/Dependency.swift
@@ -24,7 +24,7 @@
 // THE SOFTWARE.
 //
 
-import Foundation
+internal import Foundation
 
 /// Global function to resolve a keyPath on Container.shared into the requested type
 ///

--- a/Sources/FactoryKit/FactoryKit/Factory.swift
+++ b/Sources/FactoryKit/FactoryKit/Factory.swift
@@ -24,7 +24,7 @@
 // THE SOFTWARE.
 //
 
-import Foundation
+internal import Foundation
 
 public typealias ParameterFactoryType<P, T> = (P) -> T
 public typealias VoidFactoryType<T> = () -> T

--- a/Sources/FactoryKit/FactoryKit/Globals.swift
+++ b/Sources/FactoryKit/FactoryKit/Globals.swift
@@ -24,7 +24,7 @@
 // THE SOFTWARE.
 //
 
-import Foundation
+internal import Foundation
 
 // MARK: - Internal Variables
 

--- a/Sources/FactoryKit/FactoryKit/Injections.swift
+++ b/Sources/FactoryKit/FactoryKit/Injections.swift
@@ -24,12 +24,12 @@
 // THE SOFTWARE.
 //
 
-import Foundation
+internal import Foundation
 
 #if canImport(SwiftUI)
-import Combine
-import Observation
-import SwiftUI
+public import Combine
+public import Observation
+public import SwiftUI
 #endif
 
 /// Convenience property wrapper takes a factory and resolves an instance of the desired type.

--- a/Sources/FactoryKit/FactoryKit/Key.swift
+++ b/Sources/FactoryKit/FactoryKit/Key.swift
@@ -23,7 +23,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 //
-import Foundation
+internal import Foundation
 
 internal struct FactoryKey: Hashable {
 

--- a/Sources/FactoryKit/FactoryKit/Locking.swift
+++ b/Sources/FactoryKit/FactoryKit/Locking.swift
@@ -24,7 +24,7 @@
 // THE SOFTWARE.
 //
 
-import Foundation
+internal import Foundation
 
 // MARK: - Locking
 

--- a/Sources/FactoryKit/FactoryKit/Modifiers.swift
+++ b/Sources/FactoryKit/FactoryKit/Modifiers.swift
@@ -24,10 +24,10 @@
 // THE SOFTWARE.
 //
 
-import Foundation
+public import Foundation
 
 #if canImport(SwiftUI)
-import SwiftUI
+public import SwiftUI
 #endif
 
 /// Public protocol with functionality common to all Factory's. Used to add scope and decorator modifiers to Factory.

--- a/Sources/FactoryKit/FactoryKit/Registrations.swift
+++ b/Sources/FactoryKit/FactoryKit/Registrations.swift
@@ -24,7 +24,7 @@
 // THE SOFTWARE.
 //
 
-import Foundation
+internal import Foundation
 
 /// Shared registration type for Factory and ParameterFactory. Used internally to manage the registration and resolution process.
 public nonisolated struct FactoryRegistration<P,T> {

--- a/Sources/FactoryKit/FactoryKit/Resolver.swift
+++ b/Sources/FactoryKit/FactoryKit/Resolver.swift
@@ -26,7 +26,7 @@
 //  Created by Michael Long on 4/30/23.
 //
 
-import Foundation
+internal import Foundation
 
 /// When protocol is applied to a container it enables a typed registration/resolution mode.
 public protocol Resolving: ManagedContainer {

--- a/Sources/FactoryKit/FactoryKit/Scopes.swift
+++ b/Sources/FactoryKit/FactoryKit/Scopes.swift
@@ -24,8 +24,8 @@
 // THE SOFTWARE.
 //
 
-import CoreFoundation
-import Foundation
+internal import CoreFoundation
+internal import Foundation
 
 // MARK: - Scope
 

--- a/Sources/FactoryTesting/ContainerTrait.swift
+++ b/Sources/FactoryTesting/ContainerTrait.swift
@@ -28,12 +28,12 @@
 #if compiler(>=6.1)
 
 #if canImport(FactoryKit)
-import FactoryKit
+public import FactoryKit
 #elseif canImport(Factory)
-import Factory
+public import Factory
 #endif
 
-import Testing
+public import Testing
 
 /// ``ContainerTrait`` is a generic test trait that provides a scoped container for dependency injection in tests.
 ///


### PR DESCRIPTION
Enables the  upcoming Swift feature across all
targets in Package.swift. This feature (proposed for Swift 7) makes all unannotated  statements default to, preventing
accidentally reexporting transitive dependencies through a library's public API.