### PR TITLE
Fix data race in @LazyInjected and @WeakLazyInjected property wrappers

### DIFF
--- a/Sources/FactoryKit/FactoryKit/Injections.swift
+++ b/Sources/FactoryKit/FactoryKit/Injections.swift
@@ -113,50 +113,61 @@ extension Injected: @unchecked Sendable where T: Sendable {}
 
     private var thunk: () -> Factory<T>
     private var dependency: T!
-    private var initialize = true
-    
+    private var initialized = false
+    private let lock: SpinLock
+
     /// Initializes the property wrapper. The dependency isn't resolved until the wrapped value is accessed for the first time.
     /// - Parameter keyPath: KeyPath to a Factory on the default Container.
     public init(_ keyPath: KeyPath<Container, Factory<T>>) {
+        self.lock = SpinLock()
         self.thunk = { Container.shared[keyPath: keyPath] }
     }
-    
+
     /// Initializes the property wrapper. The dependency isn't resolved until the wrapped value is accessed for the first time.
     /// - Parameter keyPath: KeyPath to a Factory on the specified Container.
     public init<C:SharedContainer>(_ keyPath: KeyPath<C, Factory<T>>) {
+        self.lock = SpinLock()
         self.thunk = { C.shared[keyPath: keyPath] }
     }
-    
+
     /// Manages the wrapped dependency, which is resolved when this value is accessed for the first time.
     public var wrappedValue: T {
         mutating get {
-            if initialize {
-                resolve()
+            lock.lock()
+            defer { lock.unlock() }
+            if !initialized {
+                dependency = thunk()()
+                initialized = true
             }
             return dependency
         }
         mutating set {
+            lock.lock()
+            defer { lock.unlock() }
             dependency = newValue
+            initialized = true
         }
     }
-    
+
     /// Unwraps the property wrapper granting access to the resolve/reset function.
     public var projectedValue: LazyInjected<T> {
         get { return self }
         mutating set { self = newValue }
     }
-    
+
     /// Grants access to the internal Factory.
     public var factory: Factory<T> {
         thunk()
     }
-    
+
     /// Allows the user to force a Factory resolution at their discretion.
     public mutating func resolve(reset options: FactoryResetOptions = .none) {
+        lock.lock()
+        defer { lock.unlock() }
         let factory = thunk()
         factory.reset(options)
         dependency = factory()
-        initialize = false
+        initialized = true
     }
 
     /// Projected function returns resolved instance if it exists.
@@ -168,7 +179,9 @@ extension Injected: @unchecked Sendable where T: Sendable {}
     ///     $myService.resolvedOrNil()?.cleanup()
     /// }
     public func resolvedOrNil() -> T? {
-        dependency
+        lock.lock()
+        defer { lock.unlock() }
+        return initialized ? dependency : nil
     }
 
 }
@@ -198,50 +211,61 @@ extension LazyInjected: @unchecked Sendable where T: Sendable {}
 
     private var thunk: () -> Factory<T>
     private weak var dependency: AnyObject?
-    private var initialize = true
-    
+    private var initialized = false
+    private let lock: SpinLock
+
     /// Initializes the property wrapper. The dependency isn't resolved until the wrapped value is accessed for the first time.
     /// - Parameter keyPath: KeyPath to a Factory on the default Container.
     public init(_ keyPath: KeyPath<Container, Factory<T>>) {
+        self.lock = SpinLock()
         self.thunk = { Container.shared[keyPath: keyPath] }
     }
-    
+
     /// Initializes the property wrapper. The dependency isn't resolved until the wrapped value is accessed for the first time.
     /// - Parameter keyPath: KeyPath to a Factory on the specified Container.
     public init<C:SharedContainer>(_ keyPath: KeyPath<C, Factory<T>>) {
+        self.lock = SpinLock()
         self.thunk = { C.shared[keyPath: keyPath] }
     }
-    
+
     /// Manages the wrapped dependency, which is resolved when this value is accessed for the first time.
     public var wrappedValue: T? {
         mutating get {
-            if initialize {
-                resolve()
+            lock.lock()
+            defer { lock.unlock() }
+            if !initialized {
+                dependency = thunk()() as AnyObject
+                initialized = true
             }
             return dependency as? T
         }
         mutating set {
+            lock.lock()
+            defer { lock.unlock() }
             dependency = newValue as AnyObject
+            initialized = true
         }
     }
-    
+
     /// Unwraps the property wrapper granting access to the resolve/reset function.
     public var projectedValue: WeakLazyInjected<T> {
         get { return self }
         mutating set { self = newValue }
     }
-    
+
     /// Grants access to the internal Factory.
     public var factory: Factory<T> {
         thunk()
     }
-    
+
     /// Allows the user to force a Factory resolution at their discretion.
     public mutating func resolve(reset options: FactoryResetOptions = .none) {
+        lock.lock()
+        defer { lock.unlock() }
         let factory = thunk()
         factory.reset(options)
         dependency = factory() as AnyObject
-        initialize = false
+        initialized = true
     }
 
     /// Projected function returns resolved instance if it exists.
@@ -253,7 +277,9 @@ extension LazyInjected: @unchecked Sendable where T: Sendable {}
     ///     $myService.resolvedOrNil()?.cleanup()
     /// }
     public func resolvedOrNil() -> T? {
-        dependency as? T
+        lock.lock()
+        defer { lock.unlock() }
+        return dependency as? T
     }
 
 }

--- a/Sources/FactoryKit/FactoryKit/Locking.swift
+++ b/Sources/FactoryKit/FactoryKit/Locking.swift
@@ -65,12 +65,17 @@ internal final class RecursiveLock: NSLocking {
 nonisolated(unsafe) internal let globalVariableLock = SpinLock()
 
 #if os(macOS) || os(iOS) || os(watchOS)
-/// Custom spin lock
-internal final class SpinLock: NSLocking {
+/// Custom spin lock using os_unfair_lock on Apple platforms.
+internal final class SpinLock: NSLocking, @unchecked Sendable {
 
     init() {
         oslock = UnsafeMutablePointer<os_unfair_lock>.allocate(capacity: 1)
         oslock.initialize(to: .init())
+    }
+
+    deinit {
+        oslock.deinitialize(count: 1)
+        oslock.deallocate()
     }
 
     @inlinable @inline(__always) func lock() {
@@ -85,8 +90,8 @@ internal final class SpinLock: NSLocking {
 
 }
 #else
-/// Custom spin lock compatible with Linux
-internal final class SpinLock: NSLocking {
+/// Custom spin lock compatible with Linux using pthread_mutex.
+internal final class SpinLock: NSLocking, @unchecked Sendable {
 
     init() {
         mutex = UnsafeMutablePointer<pthread_mutex_t>.allocate(capacity: 1)
@@ -96,6 +101,11 @@ internal final class SpinLock: NSLocking {
         pthread_mutex_init(mutex, attributes)
         pthread_mutexattr_destroy(attributes)
         attributes.deallocate()
+    }
+
+    deinit {
+        pthread_mutex_destroy(mutex)
+        mutex.deallocate()
     }
 
     @inlinable @inline(__always) func lock() {

--- a/Tests/FactoryTests/XCTests/FactoryLazyInjectedThreadSafetyTests.swift
+++ b/Tests/FactoryTests/XCTests/FactoryLazyInjectedThreadSafetyTests.swift
@@ -1,0 +1,132 @@
+import XCTest
+@testable import FactoryKit
+
+// MARK: - Thread-Safety Tests for @LazyInjected and @WeakLazyInjected
+
+final class FactoryLazyInjectedThreadSafetyTests: XCTestCase, @unchecked Sendable {
+
+    override func setUp() {
+        super.setUp()
+        LazyThreadSafetyContainer.shared.reset()
+    }
+
+    /// Verifies that concurrent first-access to a @LazyInjected property does not crash.
+    /// Under TSan, this would flag the data race present in the unfixed version.
+    func testConcurrentFirstAccessDoesNotCrash() {
+        for _ in 0..<100 {
+            let object = LazyInjectedHolder()
+            DispatchQueue.concurrentPerform(iterations: 20) { _ in
+                // All threads race to trigger first resolution
+                let value = object.service
+                XCTAssertNotNil(value)
+            }
+        }
+    }
+
+    /// Verifies that a singleton-scoped factory is only resolved once despite concurrent access.
+    func testConcurrentFirstAccessResolvesOnce() {
+        let object = LazyInjectedSingletonHolder()
+        let results = LockedArray<ObjectIdentifier>()
+
+        DispatchQueue.concurrentPerform(iterations: 50) { _ in
+            let value = object.service
+            results.append(ObjectIdentifier(value))
+        }
+
+        // All results should be the same instance (singleton scope)
+        let unique = Set(results.values)
+        XCTAssertEqual(unique.count, 1, "Singleton-scoped @LazyInjected should resolve to a single instance, got \(unique.count)")
+    }
+
+    /// Verifies that concurrent first-access to a @WeakLazyInjected property does not crash.
+    func testWeakLazyInjectedConcurrentFirstAccessDoesNotCrash() {
+        for _ in 0..<100 {
+            let object = WeakLazyInjectedHolder()
+            DispatchQueue.concurrentPerform(iterations: 20) { _ in
+                _ = object.service
+            }
+        }
+    }
+
+    /// Verifies that concurrent writes to @LazyInjected do not crash.
+    func testConcurrentWriteDoesNotCrash() {
+        for _ in 0..<100 {
+            let object = LazyInjectedHolder()
+            DispatchQueue.concurrentPerform(iterations: 20) { i in
+                if i % 2 == 0 {
+                    _ = object.service
+                } else {
+                    object.service = ThreadSafeService()
+                }
+            }
+        }
+    }
+
+    /// Verifies resolvedOrNil() returns nil before first access and a value after.
+    func testResolvedOrNilThreadSafety() {
+        let object = LazyInjectedHolder()
+
+        // Before access, should be nil
+        XCTAssertNil(object.resolvedOrNil)
+
+        // Trigger resolution
+        _ = object.service
+
+        // After access, should be non-nil
+        XCTAssertNotNil(object.resolvedOrNil)
+    }
+}
+
+// MARK: - Test Helpers
+
+/// Thread-safe array wrapper for use in concurrent closures.
+private final class LockedArray<Element>: @unchecked Sendable {
+    private var storage: [Element] = []
+    private let lock = NSLock()
+
+    func append(_ element: Element) {
+        lock.lock()
+        storage.append(element)
+        lock.unlock()
+    }
+
+    var values: [Element] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+    }
+}
+
+private final class ThreadSafeService: @unchecked Sendable {
+    let id = UUID()
+    init() {
+        // Simulate non-trivial initialization
+        Thread.sleep(forTimeInterval: 0.001)
+    }
+}
+
+private final class LazyThreadSafetyContainer: SharedContainer {
+    static let shared = LazyThreadSafetyContainer()
+    var service: Factory<ThreadSafeService> { self { ThreadSafeService() } }
+    var singletonService: Factory<ThreadSafeService> { self { ThreadSafeService() }.singleton }
+    let manager = ContainerManager()
+}
+
+/// Test holder using @LazyInjected with default (unique) scope.
+private final class LazyInjectedHolder: @unchecked Sendable {
+    @LazyInjected(\LazyThreadSafetyContainer.service) var service: ThreadSafeService
+
+    var resolvedOrNil: ThreadSafeService? {
+        $service.resolvedOrNil()
+    }
+}
+
+/// Test holder using @LazyInjected with singleton scope.
+private final class LazyInjectedSingletonHolder: @unchecked Sendable {
+    @LazyInjected(\LazyThreadSafetyContainer.singletonService) var service: ThreadSafeService
+}
+
+/// Test holder using @WeakLazyInjected.
+private final class WeakLazyInjectedHolder: @unchecked Sendable {
+    @WeakLazyInjected(\LazyThreadSafetyContainer.service) var service: ThreadSafeService?
+}


### PR DESCRIPTION
## Problem

`@LazyInjected` and `@WeakLazyInjected` have a data race on first access. When multiple threads read the `wrappedValue` concurrently before the dependency has been resolved, they race on the `initialized` flag and `dependency` storage — leading to potential crashes or double resolution.

The `SpinLock` class also leaked its heap-allocated `os_unfair_lock` / `pthread_mutex_t` because it had no `deinit`.

## Fix

- Add a per-instance `SpinLock` to `LazyInjected` and `WeakLazyInjected` that synchronizes `wrappedValue` (get/set), `resolve()`, and `resolvedOrNil()`.
- Add `deinit` to `SpinLock` on both Apple (`os_unfair_lock`) and Linux (`pthread_mutex_t`) platforms to free the allocated memory.
- Mark `SpinLock` as `@unchecked Sendable` (required since it's now stored in `Sendable`-conditional structs).
- Rename `initialize` → `initialized` for clarity (old name read like a verb, not a state flag).

## Tests

New `FactoryLazyInjectedThreadSafetyTests` (XCTest) covering:
- Concurrent first-access crash
- Singleton-scoped single-resolution guarantee
- `@WeakLazyInjected` concurrent first-access
- Concurrent read/write interleaving
- `resolvedOrNil()` before/after resolution

## Declaration

The program was tested solely for our own use cases, which might differ from yours.

## Link to provider information

https://github.com/mercedes-benz
