### PR TITLE
Reduce global lock contention in Factory resolution

### DIFF
--- a/Sources/FactoryKit/FactoryKit/Containers.swift
+++ b/Sources/FactoryKit/FactoryKit/Containers.swift
@@ -210,8 +210,9 @@ extension ManagedContainer {
     }
     /// Defines a decorator for the container. This decorator will see every dependency resolved by this container.
     public func decorator(_ decorator: ((Any) -> ())?) {
-        globalVariableLock.withLock {
+        globalRecursiveLock.withLock {
             manager.state.decorator = decorator
+            manager.invalidateAllPlans()
         }
     }
     /// Defines a thread safe access mechanism to reset the container.
@@ -252,7 +253,12 @@ public final nonisolated class ContainerManager: @unchecked Sendable {
     /// Default scope. Setting scope to nil returns the default to `unique`.
     public var defaultScope: Scope? {
         get { globalVariableLock.withLock { state.defaultScope } }
-        set { globalVariableLock.withLock { state.defaultScope = newValue } }
+        set {
+            globalRecursiveLock.withLock {
+                globalVariableLock.withLock { state.defaultScope = newValue }
+                invalidateAllPlans()
+            }
+        }
     }
 
     #if DEBUG
@@ -302,16 +308,17 @@ public final nonisolated class ContainerManager: @unchecked Sendable {
     }
     #endif
 
-    /// Updated registrations for Factory's.
+    /// Updated registrations for Factory's. Only populated by runtime `.register {}` overrides.
     internal typealias FactoryMap = [FactoryKey:AnyFactory]
-    internal var registrations: FactoryMap = .init(minimumCapacity: 256)
+    internal var registrations: FactoryMap = .init(minimumCapacity: 32)
 
-    /// Updated options for Factory's.
+    /// Updated options for Factory's. Only populated by explicit scope/context modifiers.
     internal typealias FactoryOptionsMap = [FactoryKey:FactoryOptions]
-    internal var options: FactoryOptionsMap = .init(minimumCapacity: 256)
+    internal var options: FactoryOptionsMap = .init(minimumCapacity: 32)
 
     /// Scope cache for Factory's managed by this container.
-    internal var cache: Scope.Cache = Scope.Cache(minimumCapacity: 256)
+    /// Graph scope uses its own thread-local cache, so this only holds cached/shared instances.
+    internal var cache: Scope.Cache = Scope.Cache(minimumCapacity: 32)
 
     /// Push/Pop stack for registrations, options, cache, and so on.
     internal var stack: [(FactoryMap, FactoryOptionsMap, Scope.Cache.CacheMap, InternalState)] = []
@@ -321,6 +328,49 @@ public final nonisolated class ContainerManager: @unchecked Sendable {
 
     /// Flag indicating auto registration is in process.
     internal var autoRegistering = false
+
+    // MARK: - Resolution Plan Cache (fast path)
+
+    /// Monotonic generation counter incremented on every mutation (register, reset,
+    /// defaultScope, decorator). Used to detect stale deferred plan stores.
+    private var planGeneration: UInt64 = 0
+
+    /// Per-key resolution plans enabling lock-free cache-hit resolution.
+    /// Protected by a CrossPlatformLock — lightweight compared to the global recursive lock.
+    private let planLock = CrossPlatformLock()
+    private var plans: [FactoryKey: ResolutionPlan] = .init(minimumCapacity: 256)
+
+    internal var currentPlanGeneration: UInt64 {
+        planLock.withLock { planGeneration }
+    }
+
+    @inline(__always) internal func cachedPlan(for key: FactoryKey) -> ResolutionPlan? {
+        planLock.withLock { plans[key] }
+    }
+
+    internal func storePlan(_ plan: ResolutionPlan, for key: FactoryKey, ifGeneration expected: UInt64) {
+        planLock.withLock {
+            guard planGeneration == expected else { return }
+            plans[key] = plan
+        }
+    }
+
+    internal func storePlan(_ plan: ResolutionPlan, for key: FactoryKey) {
+        planLock.withLock { plans[key] = plan }
+    }
+
+    internal func invalidatePlan(for key: FactoryKey) {
+        planLock.withLock {
+            _ = plans.removeValue(forKey: key)
+        }
+    }
+
+    internal func invalidateAllPlans() {
+        planLock.withLock {
+            planGeneration &+= 1
+            plans.removeAll(keepingCapacity: true)
+        }
+    }
 
     /// Internal state value structure
     internal struct InternalState {
@@ -347,6 +397,7 @@ extension ContainerManager {
                 self.options.removeAll(keepingCapacity: true)
                 self.cache.reset()
                 self.state = .init()
+                self.invalidateAllPlans()
             case .context:
                 for (key, option) in self.options {
                     var mutable = option
@@ -354,11 +405,13 @@ extension ContainerManager {
                     mutable.contexts = nil
                     self.options[key] = mutable
                 }
+                self.invalidateAllPlans()
             case .none:
                 break
             case .registration:
                 self.registrations.removeAll(keepingCapacity: true)
                 self.state.autoRegistrationCheckNeeded = true
+                self.invalidateAllPlans()
             case .scope:
                 self.cache.reset()
             }
@@ -383,7 +436,8 @@ extension ContainerManager {
     /// Test function pushes the current registration and cache states
     public func push() {
         globalRecursiveLock.withLock {
-            stack.append((registrations, options, cache.cache, state))
+            stack.append((registrations, options, cache.snapshot(), state))
+            invalidateAllPlans()
         }
     }
 
@@ -393,8 +447,9 @@ extension ContainerManager {
             if let values = stack.popLast() {
                 registrations = values.0
                 options = values.1
-                cache.cache = values.2
+                cache.restore(values.2)
                 state = values.3
+                invalidateAllPlans()
             }
         }
     }
@@ -428,7 +483,7 @@ public protocol AutoRegistering {
 }
 
 extension ManagedContainer {
-    /// Performs autoRegistration check. Function is unsafe as it assume we're already behind the globalRecursiveLock.
+    /// Performs autoRegistration check. Function is unsafe as it assumes the globalRecursiveLock is already held.
     internal func unsafeCheckAutoRegistration() {
         if manager.state.autoRegistrationCheckNeeded {
             manager.state.autoRegistrationCheckNeeded = false

--- a/Sources/FactoryKit/FactoryKit/Globals.swift
+++ b/Sources/FactoryKit/FactoryKit/Globals.swift
@@ -26,6 +26,30 @@
 
 import Foundation
 
+// MARK: - Cross-Platform Timestamp
+
+@inline(__always)
+internal func currentTimestamp() -> Double {
+    var ts = timespec()
+    clock_gettime(CLOCK_MONOTONIC, &ts)
+    return Double(ts.tv_sec) + Double(ts.tv_nsec) / 1_000_000_000
+}
+
+// MARK: - Cross-Platform pthread Key
+
+internal func makePthreadKey(destructor: @convention(c) (UnsafeMutableRawPointer) -> Void) -> pthread_key_t {
+    var key: pthread_key_t = 0
+    #if canImport(Darwin)
+    pthread_key_create(&key, destructor)
+    #else
+    pthread_key_create(&key) { raw in
+        guard let raw else { return }
+        destructor(raw)
+    }
+    #endif
+    return key
+}
+
 // MARK: - Internal Variables
 
 /// Internal key used for Resolver mode
@@ -50,13 +74,9 @@ internal enum ThreadLocalDebugState {
         var traceResolutions: [String] = []
     }
 
-    private static let storageKey: pthread_key_t = {
-        var key: pthread_key_t = 0
-        pthread_key_create(&key) { raw in
-            Unmanaged<Storage>.fromOpaque(raw).release()
-        }
-        return key
-    }()
+    private static let storageKey: pthread_key_t = makePthreadKey { raw in
+        Unmanaged<Storage>.fromOpaque(raw).release()
+    }
 
     @inline(__always)
     private static func getStorage() -> Storage? {

--- a/Sources/FactoryKit/FactoryKit/Globals.swift
+++ b/Sources/FactoryKit/FactoryKit/Globals.swift
@@ -33,17 +33,77 @@ internal let globalResolverKey: StaticString = "*"
 
 #if DEBUG
 /// Internal variables used for debugging
-nonisolated(unsafe) internal var globalCircularDependencyKeys: Set<FactoryKey> = []
 nonisolated(unsafe) internal var globalCircularDependencyTesting = true
 nonisolated(unsafe) internal var globalLogger: (String) -> Void = { print($0) }
 nonisolated(unsafe) internal var globalTraceFlag: Bool = false
-nonisolated(unsafe) internal var globalTraceResolutions: [String] = []
+
+// MARK: - Thread-Local Debug State
+
+/// Per-thread circular dependency tracking and trace resolutions.
+/// These must be thread-local because factory closures now execute outside the global lock,
+/// meaning multiple threads can be mid-resolution simultaneously.
+/// Both values share a single TLS key to minimize pthread_getspecific calls.
+internal enum ThreadLocalDebugState {
+    /// Combined storage for all per-thread debug state.
+    private final class Storage {
+        var circularDependencyKeys: Set<FactoryKey> = []
+        var traceResolutions: [String] = []
+    }
+
+    private static let storageKey: pthread_key_t = {
+        var key: pthread_key_t = 0
+        pthread_key_create(&key) { raw in
+            Unmanaged<Storage>.fromOpaque(raw).release()
+        }
+        return key
+    }()
+
+    @inline(__always)
+    private static func getStorage() -> Storage? {
+        guard let raw = pthread_getspecific(storageKey) else { return nil }
+        return Unmanaged<Storage>.fromOpaque(raw).takeUnretainedValue()
+    }
+
+    @inline(__always)
+    private static func getOrCreateStorage() -> Storage {
+        if let storage = getStorage() { return storage }
+        let storage = Storage()
+        pthread_setspecific(storageKey, Unmanaged.passRetained(storage).toOpaque())
+        return storage
+    }
+
+    internal static var circularDependencyKeys: Set<FactoryKey> {
+        get { getStorage()?.circularDependencyKeys ?? [] }
+        set { getOrCreateStorage().circularDependencyKeys = newValue }
+    }
+
+    internal static var traceResolutions: [String] {
+        get { getStorage()?.traceResolutions ?? [] }
+        set { getOrCreateStorage().traceResolutions = newValue }
+    }
+
+    internal static func reset() {
+        guard let storage = getStorage() else { return }
+        storage.circularDependencyKeys = []
+        storage.traceResolutions = []
+    }
+}
+
+/// Convenience accessors maintaining the old global naming convention
+internal var globalCircularDependencyKeys: Set<FactoryKey> {
+    get { ThreadLocalDebugState.circularDependencyKeys }
+    set { ThreadLocalDebugState.circularDependencyKeys = newValue }
+}
+
+internal var globalTraceResolutions: [String] {
+    get { ThreadLocalDebugState.traceResolutions }
+    set { ThreadLocalDebugState.traceResolutions = newValue }
+}
 
 /// Triggers fatalError after resetting enough stuff so unit tests can continue
 internal func resetAndTriggerFatalError(_ message: String, _ file: StaticString, _ line: UInt) -> Never {
-    globalCircularDependencyKeys = []
+    ThreadLocalDebugState.reset()
     globalRecursiveLock = RecursiveLock()
-    globalTraceResolutions = []
     Scope.graph.reset()
     triggerFatalError(message, file, line) // GOES BOOM
 }

--- a/Sources/FactoryKit/FactoryKit/Locking.swift
+++ b/Sources/FactoryKit/FactoryKit/Locking.swift
@@ -26,6 +26,12 @@
 
 import Foundation
 
+#if SynchronizationLock
+import Synchronization
+#elseif AllocatedLock
+import os
+#endif
+
 // MARK: - Locking
 
 /// Master recursive lock
@@ -57,14 +63,116 @@ internal final class RecursiveLock: NSLocking {
         pthread_mutex_unlock(mutex)
     }
 
+    @inlinable @inline(__always) func withLock<R>(_ body: () throws -> R) rethrows -> R {
+        pthread_mutex_lock(mutex)
+        defer { pthread_mutex_unlock(mutex) }
+        return try body()
+    }
+
     private let mutex: UnsafeMutablePointer<pthread_mutex_t>
 
 }
 
+/// Sleeping mutex for long-lived critical sections such as factory creation.
+#if SynchronizationLock
+
+internal final class MutexLock: @unchecked Sendable {
+
+    private let mutex = Mutex(())
+
+    @inlinable @inline(__always) func withLock<R>(_ body: () throws -> R) rethrows -> R {
+        try mutex.withLock { _ in try body() }
+    }
+
+}
+
+#elseif AllocatedLock
+
+internal final class MutexLock: @unchecked Sendable {
+
+    private let unfairLock = OSAllocatedUnfairLock()
+
+    @inlinable @inline(__always) func withLock<R>(_ body: () throws -> R) rethrows -> R {
+        unfairLock.lock()
+        defer { unfairLock.unlock() }
+        return try body()
+    }
+
+}
+
+#else
+
+internal final class MutexLock {
+
+    init() {
+        mutex = UnsafeMutablePointer<pthread_mutex_t>.allocate(capacity: 1)
+        let attributes = UnsafeMutablePointer<pthread_mutexattr_t>.allocate(capacity: 1)
+        pthread_mutexattr_init(attributes)
+        pthread_mutexattr_settype(attributes, Int32(PTHREAD_MUTEX_NORMAL))
+        pthread_mutex_init(mutex, attributes)
+        pthread_mutexattr_destroy(attributes)
+        attributes.deallocate()
+    }
+
+    deinit {
+        pthread_mutex_destroy(mutex)
+        mutex.deallocate()
+    }
+
+    @inlinable @inline(__always) func withLock<R>(_ body: () throws -> R) rethrows -> R {
+        pthread_mutex_lock(mutex)
+        defer { pthread_mutex_unlock(mutex) }
+        return try body()
+    }
+
+    private let mutex: UnsafeMutablePointer<pthread_mutex_t>
+
+}
+
+#endif
+
 /// Master variable spin lock
 internal let globalVariableLock = CrossPlatformLock()
 
-#if os(macOS) || os(iOS) || os(watchOS)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
+
+#if SynchronizationLock
+
+/// Lock using Swift 6 Mutex. Zero-cost inline lock, no separate heap allocation.
+/// Requires iOS 18+ / macOS 15+ — enabled via the "SynchronizationLock" package trait.
+internal final class CrossPlatformLock: @unchecked Sendable {
+
+    private let mutex = Mutex(())
+
+    @inlinable @inline(__always) func withLock<R>(_ body: () throws -> R) rethrows -> R {
+        try mutex.withLock { _ in try body() }
+    }
+
+}
+
+#elseif AllocatedLock
+
+/// Lock using OSAllocatedUnfairLock. Single allocation, no UnsafeMutablePointer.
+/// Requires iOS 16+ / macOS 13+ — enabled via the "AllocatedLock" package trait.
+@available(iOS 16.0, *)
+internal final class CrossPlatformLock: NSLocking, @unchecked Sendable {
+
+    private let unfairLock = OSAllocatedUnfairLock()
+
+    @inlinable @inline(__always) func lock() { unfairLock.lock() }
+    @inlinable @inline(__always) func unlock() { unfairLock.unlock() }
+
+    /// Inlinable withLock avoids Foundation's non-inlinable NSLocking.withLock
+    @inlinable @inline(__always) func withLock<R>(_ body: () throws -> R) rethrows -> R {
+        unfairLock.lock()
+        defer { unfairLock.unlock() }
+        return try body()
+    }
+
+}
+
+#else
+
 /// Custom lock using os_unfair_lock on Apple platforms.
 internal final class CrossPlatformLock: NSLocking, @unchecked Sendable {
 
@@ -86,9 +194,19 @@ internal final class CrossPlatformLock: NSLocking, @unchecked Sendable {
         os_unfair_lock_unlock(oslock)
     }
 
+    /// Inlinable withLock avoids Foundation's non-inlinable NSLocking.withLock
+    @inlinable @inline(__always) func withLock<R>(_ body: () throws -> R) rethrows -> R {
+        os_unfair_lock_lock(oslock)
+        defer { os_unfair_lock_unlock(oslock) }
+        return try body()
+    }
+
     private let oslock: UnsafeMutablePointer<os_unfair_lock>
 
 }
+
+#endif
+
 #else
 /// Custom lock compatible with Linux using pthread_mutex.
 internal final class CrossPlatformLock: NSLocking, @unchecked Sendable {
@@ -114,6 +232,13 @@ internal final class CrossPlatformLock: NSLocking, @unchecked Sendable {
 
     @inlinable @inline(__always) func unlock() {
         pthread_mutex_unlock(mutex)
+    }
+
+    /// Inlinable withLock for Linux
+    @inlinable @inline(__always) func withLock<R>(_ body: () throws -> R) rethrows -> R {
+        pthread_mutex_lock(mutex)
+        defer { pthread_mutex_unlock(mutex) }
+        return try body()
     }
 
     private let mutex: UnsafeMutablePointer<pthread_mutex_t>

--- a/Sources/FactoryKit/FactoryKit/MainActorInjections.swift
+++ b/Sources/FactoryKit/FactoryKit/MainActorInjections.swift
@@ -1,0 +1,82 @@
+//
+//  MainActorInjections.swift
+//  FactoryKit
+//
+//  Lock-free lazy injection for @MainActor-isolated types.
+//
+
+import Foundation
+
+/// A lock-free lazy injection property wrapper for `@MainActor`-isolated types.
+///
+/// Behaves identically to ``LazyInjected`` but omits all locking since
+/// main actor isolation already guarantees single-threaded access.
+///
+/// Swift property wrappers cannot detect their enclosing type's actor isolation,
+/// so a separate wrapper is the best compromise until FactoryKit adopts Swift macros.
+/// A `@Injected` macro could inspect the enclosing declaration at compile time and
+/// expand to the correct code automatically — eliminating the need to choose
+/// between ``LazyInjected`` and ``MainActorLazyInjected`` manually. Macros can
+/// replace property wrappers entirely: an `@attached(peer)` emits a private backing
+/// stored property, and `@attached(accessor)` adds get/set — no wrapper struct, no
+/// lock allocation, no per-access lock acquisition. Just a plain optional + nil check.
+@MainActor
+@propertyWrapper
+public struct MainActorLazyInjected<T> {
+
+    private var dependency: T?
+    private var initialized = false
+    private let thunk: () -> Factory<T>
+
+    /// Initializes with a keyPath into the default Container.
+    public init(_ keyPath: KeyPath<Container, Factory<T>>) {
+        self.thunk = { Container.shared[keyPath: keyPath] }
+    }
+
+    /// Initializes with a keyPath into a custom SharedContainer subclass.
+    public init<C: SharedContainer>(_ keyPath: KeyPath<C, Factory<T>>) {
+        self.thunk = { C.shared[keyPath: keyPath] }
+    }
+
+    /// The resolved dependency. Resolved lazily on first access.
+    public var wrappedValue: T {
+        mutating get {
+            if !initialized {
+                dependency = thunk()()
+                initialized = true
+            }
+            return dependency!
+        }
+        mutating set {
+            dependency = newValue
+            initialized = true
+        }
+    }
+
+    /// Projected value provides access to resolve/reset and the underlying factory.
+    public var projectedValue: MainActorLazyInjected<T> {
+        get { self }
+        mutating set { self = newValue }
+    }
+
+    /// The underlying Factory.
+    public var factory: Factory<T> {
+        thunk()
+    }
+
+    /// Re-resolves the dependency, optionally resetting the factory first.
+    @discardableResult
+    public mutating func resolve(reset options: FactoryResetOptions = .none) -> T {
+        let factory = thunk()
+        factory.reset(options)
+        let value = factory()
+        dependency = value
+        initialized = true
+        return value
+    }
+
+    /// Returns the resolved dependency if it has been initialized, nil otherwise.
+    public func resolvedOrNil() -> T? {
+        initialized ? dependency : nil
+    }
+}

--- a/Sources/FactoryKit/FactoryKit/Registrations.swift
+++ b/Sources/FactoryKit/FactoryKit/Registrations.swift
@@ -84,7 +84,7 @@ public nonisolated struct FactoryRegistration<P,T> {
                 if let existing = plan.cache.value(forKey: lookupKey),
                    let cached: T = scope.unboxed(box: existing) {
                     if let ttl = plan.ttl {
-                        let now = CFAbsoluteTimeGetCurrent()
+                        let now = currentTimestamp()
                         if (existing.timestamp + ttl) > now {
                             plan.cache.set(timestamp: now, forKey: lookupKey)
                             if canUseFastPath { return cached }

--- a/Sources/FactoryKit/FactoryKit/Registrations.swift
+++ b/Sources/FactoryKit/FactoryKit/Registrations.swift
@@ -48,43 +48,160 @@ public nonisolated struct FactoryRegistration<P,T> {
 
     /// Resolves a Factory, returning an instance of the desired type. All roads lead here.
     ///
+    /// Resolution uses a fast path for cache hits that avoids the global lock entirely,
+    /// with a slow path fallback that builds the resolution plan on first access.
+    ///
+    /// **Consistency model:** A resolve in flight concurrently with a registration may still
+    /// return a previously cached value (eventual consistency). All subsequent resolves after
+    /// registration completes are guaranteed to see the new factory. This trade-off is acceptable
+    /// because registrations are typically performed at startup or in tests, not during steady-state.
+    ///
     /// - Parameter factory: Factory wanting resolution.
     /// - Returns: Instance of the desired type.
     internal func resolve(with parameters: P) -> T {
-        defer { globalRecursiveLock.unlock()  }
-        globalRecursiveLock.lock()
 
-        container.unsafeCheckAutoRegistration()
+        // ═══════════════════════════════════════════════════════════════════
+        // FAST PATH: Cache hit without global lock (steady-state 95%+ case)
+        // Only requires read locks — no global recursive lock, no TLS.
+        // ═══════════════════════════════════════════════════════════════════
 
         let manager: ContainerManager = container.manager
-        let options: FactoryOptions? = manager.options[key]
-
-        var current: (P) -> T
 
         #if DEBUG
-        let traceIndex: Int = globalTraceResolutions.count
-        let traceLevel: Int = Scope.graph.depth
-        var traceNewType: String
+        let tracingEnabled = globalTraceFlag
         #endif
 
-        if let found = options?.factoryForCurrentContext() as? TypedFactory<P,T> {
+        if let plan = manager.cachedPlan(for: key) {
+
             #if DEBUG
-            traceNewType = "O" // .onTest, .onDebug, etc.
+            let canUseFastPath = !tracingEnabled && !plan.hasDecorator && !plan.hasManagerDecorator
+            #else
+            let canUseFastPath = !plan.hasDecorator && !plan.hasManagerDecorator
             #endif
-            current = found.factory
-        } else if let found = manager.registrations[key] as? TypedFactory<P,T> {
-            #if DEBUG
-            traceNewType = "R" // .register {}
-            #endif
-            current = found.factory
-        } else {
-            #if DEBUG
-            traceNewType = "F" // Factory { ... }
-            #endif
-            current = factory
+
+            if let scope = plan.scope {
+                let lookupKey = plan.scopeOnParameters ? key.parameterized(parameters) : key
+                if let existing = plan.cache.value(forKey: lookupKey),
+                   let cached: T = scope.unboxed(box: existing) {
+                    if let ttl = plan.ttl {
+                        let now = CFAbsoluteTimeGetCurrent()
+                        if (existing.timestamp + ttl) > now {
+                            plan.cache.set(timestamp: now, forKey: lookupKey)
+                            if canUseFastPath { return cached }
+                        }
+                        // TTL expired or needs decorator/trace — fall through
+                    } else {
+                        if canUseFastPath { return cached }
+                    }
+                }
+            } else {
+                // Unique-scope fast path — no lock, no cache, just call the factory.
+                // Plan with nil scope is only stored when no override exists.
+                if canUseFastPath {
+                    Scope.graph.enter()
+                    let result = factory(parameters)
+                    Scope.graph.leave()
+                    return result
+                }
+            }
         }
 
+        // ═══════════════════════════════════════════════════════════════════
+        // SLOW PATH: Full resolution with global lock (first resolve or cache miss)
+        // ═══════════════════════════════════════════════════════════════════
+
+        return resolveSlow(with: parameters, manager: manager)
+    }
+
+    /// Slow path: takes global lock, reads options/registrations, executes factory if needed.
+    @inline(never)
+    private func resolveSlow(with parameters: P, manager: ContainerManager) -> T {
+
+        // Phase 1: Under global lock — lookups only (nanoseconds)
+
+        let current: (P) -> T
+        let scope: Scope?
+        let resolvedCache: Scope.Cache
+        let parameterizedKey: FactoryKey
+        let ttl: TimeInterval?
+        let decorator: ((T, Bool) -> Void)?
+        let managerDecorator: ((Any) -> ())?
+        var shouldStorePlanAfterFactory = false
+        var planGeneration: UInt64 = 0
+
         #if DEBUG
+        var traceNewType: String = "F"
+        #endif
+
+        do {
+            globalRecursiveLock.lock()
+            defer { globalRecursiveLock.unlock() }
+
+            container.unsafeCheckAutoRegistration()
+
+            let options: FactoryOptions? = manager.options[key]
+
+            let isOriginalFactory: Bool
+
+            if let found = options?.factoryForCurrentContext() as? TypedFactory<P,T> {
+                #if DEBUG
+                traceNewType = "O"
+                #endif
+                current = found.factory
+                isOriginalFactory = false
+            } else if let found = manager.registrations[key] as? TypedFactory<P,T> {
+                #if DEBUG
+                traceNewType = "R"
+                #endif
+                current = found.factory
+                isOriginalFactory = false
+            } else {
+                #if DEBUG
+                traceNewType = "F"
+                #endif
+                current = factory
+                isOriginalFactory = true
+            }
+
+            scope = options?.scope ?? manager.defaultScope
+            parameterizedKey = options?.scopeOnParameters == true ? key.parameterized(parameters) : key
+            ttl = options?.ttl
+            decorator = options?.decorator as? (T, Bool) -> Void
+            managerDecorator = manager.state.decorator
+
+            if let s = scope {
+                resolvedCache = (s as? InternalScopeCaching)?.cache ?? manager.cache
+            } else {
+                resolvedCache = manager.cache
+            }
+
+            // Build and cache the resolution plan for future fast-path use
+            if scope != nil {
+                let plan = ResolutionPlan(
+                    scope: scope,
+                    cache: resolvedCache,
+                    ttl: ttl,
+                    scopeOnParameters: options?.scopeOnParameters ?? false,
+                    hasDecorator: decorator != nil,
+                    hasManagerDecorator: managerDecorator != nil
+                )
+                manager.storePlan(plan, for: key)
+            } else if isOriginalFactory {
+                // Defer storing the unique-scope plan until after the factory
+                // executes (phase 2). Storing it here would let recursive
+                // resolves of the same key hit the fast path, bypassing the
+                // circular dependency check in resolveSlow.
+                shouldStorePlanAfterFactory = true
+                planGeneration = manager.currentPlanGeneration
+            }
+        }
+
+        // DEBUG: Trace + circular dependency detection
+
+        #if DEBUG
+        let traceLevel: Int = Scope.graph.depth
+        let traceIndex: Int = globalTraceResolutions.count
+
         if globalTraceFlag {
             let indent = String(repeating: "    ", count: traceLevel)
             let entry = "\(traceLevel): \(indent)\(type(of: container)).\(key.key)<\(T.self)>"
@@ -98,17 +215,37 @@ public nonisolated struct FactoryRegistration<P,T> {
         }
         #endif
 
+        // Phase 2: No global lock — execute factory closure
+
         Scope.graph.enter()
 
         let (instance, instantiated): (T, Bool)
-        if let scope = options?.scope ?? manager.defaultScope {
-            let parameterizedKey = options?.scopeOnParameters == true ? key.parameterized(parameters) : key
-            (instance, instantiated) = scope.resolve(using: manager.cache, key: parameterizedKey, ttl: options?.ttl, factory: { current(parameters) }) }
-        else {
+        if let scope = scope {
+            (instance, instantiated) = scope.resolve(using: resolvedCache, key: parameterizedKey, ttl: ttl, factory: { current(parameters) })
+        } else {
             (instance, instantiated) = (current(parameters), true)
         }
 
         Scope.graph.leave()
+
+        // Store the unique-scope plan now that the factory has executed
+        // successfully. This is deferred from phase 1 so that circular
+        // dependencies are caught by the slow path's detection logic.
+        // Uses generation check to avoid storing a stale plan if a concurrent
+        // register/reset/decorator change occurred during phase 2.
+        if shouldStorePlanAfterFactory {
+            let plan = ResolutionPlan(
+                scope: nil,
+                cache: resolvedCache,
+                ttl: nil,
+                scopeOnParameters: false,
+                hasDecorator: decorator != nil,
+                hasManagerDecorator: managerDecorator != nil
+            )
+            manager.storePlan(plan, for: key, ifGeneration: planGeneration)
+        }
+
+        // Phase 3: Decorators
 
         #if DEBUG
         if globalCircularDependencyTesting {
@@ -127,11 +264,11 @@ public nonisolated struct FactoryRegistration<P,T> {
         }
         #endif
 
-        if let decorator = options?.decorator as? (T, Bool) -> Void {
+        if let decorator = decorator {
             decorator(instance, instantiated)
         }
-        if let decorator = manager.state.decorator {
-            decorator(instance)
+        if let managerDecorator = managerDecorator {
+            managerDecorator(instance)
         }
 
         return instance
@@ -143,6 +280,10 @@ extension FactoryRegistration {
 
     /// Registers a new factory closure capable of producing an object or service of the desired type. This factory overrides the original factory and
     /// the next time this factory is resolved Factory will evaluate the newly registered factory instead.
+    ///
+    /// - Note: Registration invalidates the resolution plan cache and clears any cached scope value for this key.
+    ///   A concurrent `resolve()` already in flight on another thread may still return a previously cached value if it read
+    ///   the cache before this registration completed. Subsequent resolves are guaranteed to use the new factory.
     /// - Parameters:
     ///   - id: ID of associated Factory.
     ///   - factory: Factory closure called to create a new instance of the service when needed.
@@ -153,6 +294,7 @@ extension FactoryRegistration {
         if unsafeCanUpdateOptions() {
             let manager = container.manager
             manager.registrations[key] = TypedFactory(factory: factory)
+            manager.invalidatePlan(for: key)
             if manager.autoRegistering == false, let scope = manager.options[key]?.scope {
                 let cache = (scope as? InternalScopeCaching)?.cache ?? manager.cache
                 cache.removeValue(forKey: key)
@@ -172,9 +314,11 @@ extension FactoryRegistration {
                 options.scope = scope
                 manager.options[key] = options
                 manager.cache.removeValue(forKey: key)
+                manager.invalidatePlan(for: key)
             }
         } else {
             manager.options[key] = FactoryOptions(scope: scope)
+            manager.invalidatePlan(for: key)
         }
     }
 
@@ -229,6 +373,7 @@ extension FactoryRegistration {
             cache.removeValue(forKey: key)
             manager.registrations.removeValue(forKey: key)
             manager.options.removeValue(forKey: key)
+            manager.invalidatePlan(for: key)
         case .context:
             self.options {
                 $0.argumentContexts = nil
@@ -238,6 +383,7 @@ extension FactoryRegistration {
             break
         case .registration:
             manager.registrations.removeValue(forKey: key)
+            manager.invalidatePlan(for: key)
         case .scope:
             let cache = (manager.options[key]?.scope as? InternalScopeCaching)?.cache ?? manager.cache
             cache.removeValue(forKey: key)
@@ -254,6 +400,7 @@ extension FactoryRegistration {
         if options.once == once {
             mutate(&options)
             manager.options[key] = options
+            manager.invalidatePlan(for: key)
         }
     }
 
@@ -346,4 +493,17 @@ internal protocol AnyFactory {}
 
 internal struct TypedFactory<P,T>: AnyFactory {
     let factory: (P) -> T
+}
+
+// MARK: - Resolution Plan
+
+/// Lightweight per-key snapshot of resolution metadata, enabling lock-free cache-hit resolution.
+/// Built on first resolve, invalidated when write operations change the relevant state.
+internal struct ResolutionPlan {
+    let scope: Scope?
+    let cache: Scope.Cache
+    let ttl: TimeInterval?
+    let scopeOnParameters: Bool
+    let hasDecorator: Bool
+    let hasManagerDecorator: Bool
 }

--- a/Sources/FactoryKit/FactoryKit/Scopes.swift
+++ b/Sources/FactoryKit/FactoryKit/Scopes.swift
@@ -69,11 +69,11 @@ public class Scope: @unchecked Sendable {
     fileprivate func box<T>(_ instance: T) -> AnyBox? {
         if let optional = instance as? OptionalProtocol {
             if optional.hasWrappedValue {
-                return StrongBox<T>(scopeID: scopeID, timestamp: CFAbsoluteTimeGetCurrent(), boxed: instance)
+                return StrongBox<T>(scopeID: scopeID, timestamp: currentTimestamp(), boxed: instance)
             }
             return nil
         }
-        return StrongBox<T>(scopeID: scopeID, timestamp: CFAbsoluteTimeGetCurrent(), boxed: instance)
+        return StrongBox<T>(scopeID: scopeID, timestamp: currentTimestamp(), boxed: instance)
     }
 
     internal let scopeID: UUID = UUID()
@@ -143,14 +143,9 @@ extension Scope {
             return key
         }()
 
-        private static let cacheKey: pthread_key_t = {
-            var key: pthread_key_t = 0
-            pthread_key_create(&key) { rawPointer in
-                // Clean up the cache when the thread exits
-                Unmanaged<Cache>.fromOpaque(rawPointer).release()
-            }
-            return key
-        }()
+        private static let cacheKey: pthread_key_t = makePthreadKey { rawPointer in
+            Unmanaged<Cache>.fromOpaque(rawPointer).release()
+        }
 
         private var threadLocalDepth: Int {
             get {
@@ -194,10 +189,10 @@ extension Scope {
         fileprivate override func box<T>(_ instance: T) -> AnyBox? {
             if let optional = instance as? OptionalProtocol {
                 if let unwrapped = optional.wrappedValue, type(of: unwrapped) is AnyObject.Type {
-                    return WeakBox(scopeID: scopeID, timestamp: CFAbsoluteTimeGetCurrent(), boxed: unwrapped as AnyObject)
+                    return WeakBox(scopeID: scopeID, timestamp: currentTimestamp(), boxed: unwrapped as AnyObject)
                 }
             } else if type(of: instance as Any) is AnyObject.Type {
-                return WeakBox(scopeID: scopeID, timestamp: CFAbsoluteTimeGetCurrent(), boxed: instance as AnyObject)
+                return WeakBox(scopeID: scopeID, timestamp: currentTimestamp(), boxed: instance as AnyObject)
             }
             return nil
         }
@@ -325,7 +320,7 @@ extension Scope {
             if let existing = lock.withLock({ cache[key] }) {
                 if let cached: T = scope.unboxed(box: existing) {
                     if let ttl = ttl {
-                        let now = CFAbsoluteTimeGetCurrent()
+                        let now = currentTimestamp()
                         if (existing.timestamp + ttl) > now {
                             lock.withLock { cache[key]?.timestamp = now }
                             return (cached, false)
@@ -367,7 +362,7 @@ extension Scope {
                     // Double-check cache after acquiring per-key lock
                     if let existing = lock.withLock({ cache[key] }), let cached: T = scope.unboxed(box: existing) {
                         if let ttl = ttl {
-                            let now = CFAbsoluteTimeGetCurrent()
+                            let now = currentTimestamp()
                             if (existing.timestamp + ttl) > now {
                                 lock.withLock { cache[key]?.timestamp = now }
                                 return (cached, false)

--- a/Sources/FactoryKit/FactoryKit/Scopes.swift
+++ b/Sources/FactoryKit/FactoryKit/Scopes.swift
@@ -57,26 +57,11 @@ public class Scope: @unchecked Sendable {
 
     /// Internal function returns cached value if it exists. Otherwise it creates a new instance and caches that value for later reference.
     internal func resolve<T>(using cache: Cache, key: FactoryKey, ttl: TimeInterval?, factory: () -> T) -> (T, Bool) {
-        if let box = cache.value(forKey: key), let cached: T = unboxed(box: box) {
-            if let ttl = ttl {
-                let now = CFAbsoluteTimeGetCurrent()
-                if (box.timestamp + ttl) > now {
-                    cache.set(timestamp: now, forKey: key)
-                    return (cached, false)
-                }
-            } else {
-                return (cached, false)
-            }
-        }
-        let instance = factory()
-        if let box = box(instance) {
-             cache.set(value: box, forKey: key)
-        }
-        return (instance, true)
+        cache.resolve(key: key, ttl: ttl, scope: self, factory: factory)
     }
 
     /// Internal function returns unboxed value if it exists
-    fileprivate func unboxed<T>(box: AnyBox?) -> T? {
+    internal func unboxed<T>(box: AnyBox?) -> T? {
         (box as? StrongBox<T>)?.boxed
     }
 
@@ -106,6 +91,9 @@ extension Scope {
         public override init() {
             super.init()
         }
+        internal override func resolve<T>(using cache: Cache, key: FactoryKey, ttl: TimeInterval?, factory: () -> T) -> (T, Bool) {
+            cache.resolve(key: key, ttl: ttl, scope: self, factory: factory, exclusiveCreation: true)
+        }
     }
 
     /// A reference to the default graph scope manager.
@@ -113,34 +101,74 @@ extension Scope {
     /// Defines the graph scope. A single instance of a given type will be returned during a given resolution cycle.
     ///
     /// This scope is managed and cleared by the main resolution function at the end of each resolution cycle.
+    /// Thread safety: Each thread gets its own graph cache via thread-local storage, so concurrent
+    /// resolutions do not interfere with each other's resolution cycles.
     public final class Graph: Scope, @unchecked Sendable  {
         internal override init() {
             super.init()
         }
         internal override func resolve<T>(using cache: Cache, key: FactoryKey, ttl: TimeInterval?, factory: () -> T) -> (T, Bool) {
-            // ignore container's cache in favor of our own
-            return super.resolve(using: self.cache, key: key, ttl: ttl, factory: factory)
+            // Use the thread-local graph cache instead of the container's cache
+            let graphCache = threadLocalCache
+            return super.resolve(using: graphCache, key: key, ttl: ttl, factory: factory)
         }
-        // call to enter a new resolution level
+        /// Enter a new resolution level on the current thread
         internal func enter() {
-            depth += 1
+            let current = threadLocalDepth
+            threadLocalDepth = current + 1
         }
-        // call to leave the current resolution level
+        /// Leave the current resolution level on the current thread
         internal func leave() {
-            depth -= 1
-            if depth == 0 {
-                cache.reset()
+            let current = threadLocalDepth - 1
+            threadLocalDepth = current
+            if current == 0 {
+                threadLocalCache.reset()
             }
         }
-        // reset graph scope
+        /// Reset graph scope (used in error recovery)
         internal func reset() {
-            depth = 0
-            cache.reset()
+            threadLocalDepth = 0
+            threadLocalCache.reset()
         }
-        // depth of current resolution level
-        public private(set) var depth: Int = 0
-        /// Private shared cache
-        internal var cache = Cache()
+        /// Depth of current resolution level (per-thread)
+        public var depth: Int {
+            threadLocalDepth
+        }
+
+        // MARK: - Thread-Local Storage
+
+        private static let depthKey: pthread_key_t = {
+            var key: pthread_key_t = 0
+            pthread_key_create(&key, nil)
+            return key
+        }()
+
+        private static let cacheKey: pthread_key_t = {
+            var key: pthread_key_t = 0
+            pthread_key_create(&key) { rawPointer in
+                // Clean up the cache when the thread exits
+                Unmanaged<Cache>.fromOpaque(rawPointer).release()
+            }
+            return key
+        }()
+
+        private var threadLocalDepth: Int {
+            get {
+                Int(bitPattern: pthread_getspecific(Graph.depthKey))
+            }
+            set {
+                pthread_setspecific(Graph.depthKey, UnsafeRawPointer(bitPattern: newValue))
+            }
+        }
+
+        private var threadLocalCache: Cache {
+            if let raw = pthread_getspecific(Graph.cacheKey) {
+                return Unmanaged<Cache>.fromOpaque(raw).takeUnretainedValue()
+            }
+            let cache = Cache(minimumCapacity: 16)
+            pthread_setspecific(Graph.cacheKey, Unmanaged.passRetained(cache).toOpaque())
+            return cache
+        }
     }
 
     /// A reference to the default shared scope manager.
@@ -150,7 +178,7 @@ extension Scope {
         public override init() {
             super.init()
         }
-        fileprivate override func unboxed<T>(box: AnyBox?) -> T? {
+        internal override func unboxed<T>(box: AnyBox?) -> T? {
             if let box = box as? WeakBox, let instance = box.boxed as? T {
                 if let optional = instance as? OptionalProtocol {
                     if optional.hasWrappedValue {
@@ -192,8 +220,8 @@ extension Scope {
             super.init()
         }
         internal override func resolve<T>(using cache: Cache, key: FactoryKey, ttl: TimeInterval?, factory: () -> T) -> (T, Bool) {
-            // ignore container's cache in favor of our own
-            return super.resolve(using: self.cache, key: key, ttl: ttl, factory: factory)
+            // Use our own cache with exclusive creation to guarantee the factory runs exactly once
+            self.cache.resolve(key: key, ttl: ttl, scope: self, factory: factory, exclusiveCreation: true)
         }
         /// Private shared cache
         internal var cache: Cache
@@ -230,43 +258,165 @@ extension Scope {
 
 extension Scope {
     /// Internal class that manages scope caching for containers and scopes.
+    ///
+    /// Thread safety: All access is protected by an internal CrossPlatformLock, allowing
+    /// cache operations to be performed without holding the global recursive lock.
+    /// Per-key creation locks use a sleeping mutex to avoid spinning during factory creation.
     internal final class Cache {
         typealias CacheMap = [FactoryKey:AnyBox]
+
+        private let lock = CrossPlatformLock()
+        private let creationLockGuard = CrossPlatformLock()
+        /// Per-key creation locks for exclusive creation (singleton guarantee).
+        private var creationLocks: [FactoryKey: MutexLock] = [:]
+
         /// Internal support functions
         @inlinable @inline(__always) func value(forKey key: FactoryKey) -> AnyBox? {
-            cache[key]
+            lock.withLock { cache[key] }
         }
         @inlinable @inline(__always) func set(value: AnyBox, forKey key: FactoryKey)  {
-            cache[key] = value
+            lock.withLock { cache[key] = value }
         }
         @inlinable @inline(__always) func set(timestamp: Double, forKey key: FactoryKey)  {
-            cache[key]?.timestamp = timestamp
+            lock.withLock { cache[key]?.timestamp = timestamp }
         }
         @inlinable @inline(__always) func removeValue(forKey key: FactoryKey) {
-            cache = cache.filter { $0.key.normalized() != key }
+            lock.withLock { cache = cache.filter { $0.key.normalized() != key } }
+            creationLockGuard.withLock {
+                creationLocks = creationLocks.filter { $0.key.normalized() != key }
+            }
         }
         internal func reset(scopeID: UUID) {
-            cache = cache.filter { $1.scopeID != scopeID }
+            lock.withLock { cache = cache.filter { $1.scopeID != scopeID } }
+            creationLockGuard.withLock {
+                creationLocks.removeAll(keepingCapacity: true)
+            }
         }
         /// Internal function to clear cache if needed
         internal func reset() {
-            if !cache.isEmpty {
+            lock.withLock {
                 cache.removeAll(keepingCapacity: true)
             }
+            creationLockGuard.withLock {
+                creationLocks.removeAll(keepingCapacity: true)
+            }
         }
+
+        /// Atomic get-or-create: returns cached value if present, otherwise executes
+        /// the factory closure (without holding the cache lock) and stores the result.
+        ///
+        /// Takes the `scope` directly instead of closure trampolines for unbox/box,
+        /// eliminating 2 heap-allocated closure contexts per resolve call.
+        ///
+        /// When `exclusiveCreation` is true (used by singleton/cached scope), a per-key lock
+        /// ensures only one thread ever executes the factory for a given key. Other threads
+        /// wait and receive the cached result.
+        ///
+        /// When `exclusiveCreation` is false (default), concurrent cache misses for the same
+        /// key may both create instances. First write wins — matches Swift's `lazy var` semantics.
+        internal func resolve<T>(
+            key: FactoryKey,
+            ttl: TimeInterval?,
+            scope: Scope,
+            factory: () -> T,
+            exclusiveCreation: Bool = false
+        ) -> (T, Bool) {
+            // Fast path: check cache
+            if let existing = lock.withLock({ cache[key] }) {
+                if let cached: T = scope.unboxed(box: existing) {
+                    if let ttl = ttl {
+                        let now = CFAbsoluteTimeGetCurrent()
+                        if (existing.timestamp + ttl) > now {
+                            lock.withLock { cache[key]?.timestamp = now }
+                            return (cached, false)
+                        }
+                        // TTL expired — fall through to slow path
+                    } else {
+                        return (cached, false)
+                    }
+                }
+            }
+
+            if exclusiveCreation {
+                // Singleton/cached guarantee: per-key lock ensures only one thread creates.
+                //
+                // NOTE: The per-key MutexLock is non-recursive. A circular dependency on
+                // scoped factories (e.g. A → B → A, all singletons) will deadlock the
+                // calling thread in release builds. In DEBUG builds, circular dependencies
+                // are detected earlier by `globalCircularDependencyKeys` in `resolveSlow`
+                // before reaching this point. This trade-off is acceptable: circular
+                // dependencies are always programmer errors, and DEBUG detection covers
+                // the development cycle.
+                let keyLock: MutexLock = creationLockGuard.withLock {
+                    if let existing = creationLocks[key] {
+                        return existing
+                    } else {
+                        let newLock = MutexLock()
+                        creationLocks[key] = newLock
+                        return newLock
+                    }
+                }
+
+                return keyLock.withLock {
+                    defer {
+                        // Auto-prune: creation lock served its purpose, free the MutexLock.
+                        // Any thread already holding a reference to this lock is unaffected.
+                        creationLockGuard.withLock { _ = creationLocks.removeValue(forKey: key) }
+                    }
+
+                    // Double-check cache after acquiring per-key lock
+                    if let existing = lock.withLock({ cache[key] }), let cached: T = scope.unboxed(box: existing) {
+                        if let ttl = ttl {
+                            let now = CFAbsoluteTimeGetCurrent()
+                            if (existing.timestamp + ttl) > now {
+                                lock.withLock { cache[key]?.timestamp = now }
+                                return (cached, false)
+                            }
+                        } else {
+                            return (cached, false)
+                        }
+                    }
+
+                    let instance = factory()
+                    if let boxed = scope.box(instance) {
+                        lock.withLock { cache[key] = boxed }
+                    }
+                    return (instance, true)
+                }
+            }
+
+            // Non-exclusive: create instance WITHOUT holding cache lock (first-write-wins)
+            let instance = factory()
+
+            // Write back
+            if let boxed = scope.box(instance) {
+                lock.withLock { cache[key] = boxed }
+            }
+
+            return (instance, true)
+        }
+
         var cache: CacheMap
-        internal init(minimumCapacity: Int = 1024) {
+        internal init(minimumCapacity: Int = 32) {
             self.cache = .init(minimumCapacity: minimumCapacity)
         }
         internal init(copy: CacheMap) {
             self.cache = copy
         }
         internal func clone() -> Cache {
-            .init(copy: cache)
+            lock.withLock { .init(copy: cache) }
+        }
+        /// Returns a snapshot of the cache dictionary under the internal lock.
+        internal func snapshot() -> CacheMap {
+            lock.withLock { cache }
+        }
+        /// Replaces the cache dictionary under the internal lock.
+        internal func restore(_ map: CacheMap) {
+            lock.withLock { cache = map }
         }
         #if DEBUG
         internal var isEmpty: Bool {
-            cache.isEmpty
+            lock.withLock { cache.isEmpty }
         }
         #endif
     }

--- a/Tests/FactoryTests/XCTests/FactoryConcurrencyStressTests.swift
+++ b/Tests/FactoryTests/XCTests/FactoryConcurrencyStressTests.swift
@@ -1,0 +1,241 @@
+import XCTest
+@testable import FactoryKit
+
+/// Stress tests verifying that the split-lock resolution is thread-safe.
+final class FactoryConcurrencyStressTests: XCTestCase, @unchecked Sendable {
+
+    override func setUp() {
+        super.setUp()
+        StressContainer.shared.manager.reset()
+        Scope.singleton.reset()
+    }
+
+    /// Verifies that singleton scope returns the same instance across all threads.
+    func testSingletonConsistencyUnderContention() throws {
+        let threadCount = 100
+        let group = DispatchGroup()
+        let queue = DispatchQueue(label: "singleton-stress", attributes: .concurrent)
+
+        let results = UnsafeMutableBufferPointer<ObjectIdentifier?>.allocate(capacity: threadCount)
+        results.initialize(repeating: nil)
+
+        for i in 0..<threadCount {
+            group.enter()
+            queue.async {
+                let instance = StressContainer.shared.singletonService()
+                results[i] = ObjectIdentifier(instance)
+                group.leave()
+            }
+        }
+
+        let result = group.wait(timeout: .now() + 30)
+        XCTAssertEqual(result, .success)
+
+        let first = results[0]
+        XCTAssertNotNil(first)
+        for i in 1..<threadCount {
+            XCTAssertEqual(results[i], first, "Thread \(i) got a different singleton instance")
+        }
+        results.deallocate()
+    }
+
+    /// Verifies that the singleton factory closure executes exactly once,
+    /// even under heavy concurrent contention.
+    func testSingletonFactoryCalledExactlyOnce() throws {
+        let threadCount = 100
+        let group = DispatchGroup()
+        let queue = DispatchQueue(label: "singleton-once", attributes: .concurrent)
+
+        CountedService.resetCount()
+
+        for _ in 0..<threadCount {
+            group.enter()
+            queue.async {
+                let _ = StressContainer.shared.countedSingleton()
+                group.leave()
+            }
+        }
+
+        let result = group.wait(timeout: .now() + 30)
+        XCTAssertEqual(result, .success)
+        XCTAssertEqual(CountedService.creationCount, 1,
+                       "Singleton factory must execute exactly once, but ran \(CountedService.creationCount) times")
+    }
+
+    /// Verifies that cached scope returns stable instances under contention.
+    func testCachedScopeStability() throws {
+        let threadCount = 50
+        let iterations = 100
+        let group = DispatchGroup()
+        let queue = DispatchQueue(label: "cached-stress", attributes: .concurrent)
+
+        // Pre-warm to establish the cached instance
+        let expected = ObjectIdentifier(StressContainer.shared.cachedService())
+
+        let failures = UnsafeMutablePointer<Int>.allocate(capacity: 1)
+        failures.initialize(to: 0)
+        let failureLock = NSLock()
+
+        for _ in 0..<threadCount {
+            group.enter()
+            queue.async {
+                for _ in 0..<iterations {
+                    let instance = StressContainer.shared.cachedService()
+                    if ObjectIdentifier(instance) != expected {
+                        failureLock.lock()
+                        failures.pointee += 1
+                        failureLock.unlock()
+                    }
+                }
+                group.leave()
+            }
+        }
+
+        let result = group.wait(timeout: .now() + 30)
+        XCTAssertEqual(result, .success)
+        XCTAssertEqual(failures.pointee, 0, "Cached scope returned different instances")
+        failures.deallocate()
+    }
+
+    /// Verifies graph scope shares instances within a resolution cycle but not across threads.
+    func testGraphScopeIsolation() throws {
+        let threadCount = 50
+        let group = DispatchGroup()
+        let queue = DispatchQueue(label: "graph-stress", attributes: .concurrent)
+
+        let results = UnsafeMutableBufferPointer<Bool>.allocate(capacity: threadCount)
+        results.initialize(repeating: false)
+
+        for i in 0..<threadCount {
+            group.enter()
+            queue.async {
+                let parent = StressContainer.shared.graphParent()
+                results[i] = (parent.child1 === parent.child2)
+                group.leave()
+            }
+        }
+
+        let result = group.wait(timeout: .now() + 30)
+        XCTAssertEqual(result, .success)
+
+        for i in 0..<threadCount {
+            XCTAssertTrue(results[i], "Thread \(i): graph scope didn't share instance within cycle")
+        }
+        results.deallocate()
+    }
+
+    /// Verifies that adding a decorator after the first resolve invalidates the plan
+    /// and the decorator fires on subsequent resolves.
+    func testDecoratorAddedAfterFirstResolveFiresOnSubsequentResolves() throws {
+        let first = StressContainer.shared.cachedService()
+        XCTAssertNotNil(first)
+
+        let counter = CallCounter()
+        StressContainer.shared.cachedService.decorator { _ in
+            counter.increment()
+        }
+
+        let resolveCount = 10
+        for _ in 0..<resolveCount {
+            let _ = StressContainer.shared.cachedService()
+        }
+
+        XCTAssertEqual(counter.value, resolveCount,
+                       "Decorator added after first resolve must fire on all subsequent resolves, " +
+                       "but was called \(counter.value) times instead of \(resolveCount)")
+    }
+
+    /// Verifies that the container-level decorator fires after plan invalidation.
+    func testManagerDecoratorInvalidatesPlan() throws {
+        let _ = StressContainer.shared.s0()
+
+        let counter = CallCounter()
+        StressContainer.shared.decorator { _ in
+            counter.increment()
+        }
+
+        let _ = StressContainer.shared.s0()
+        let _ = StressContainer.shared.s0()
+
+        XCTAssertEqual(counter.value, 2,
+                       "Manager decorator must fire after being set, but was called \(counter.value) times")
+        StressContainer.shared.decorator(nil)
+    }
+}
+
+// MARK: - Test Helpers
+
+private final class StressContainer: SharedContainer {
+    static let shared = StressContainer()
+    let manager = ContainerManager()
+
+    var s0: Factory<StressService> { self { StressService() } }
+
+    var cachedService: Factory<StressService> {
+        self { StressService() }.cached
+    }
+
+    var singletonService: Factory<StressService> {
+        self { StressService() }.singleton
+    }
+
+    var countedSingleton: Factory<CountedService> {
+        self { CountedService() }.singleton
+    }
+
+    var graphParent: Factory<GraphParent> {
+        self { GraphParent(child1: self.graphChild(), child2: self.graphChild()) }
+    }
+
+    var graphChild: Factory<StressService> {
+        self { StressService() }.graph
+    }
+}
+
+private class StressService {
+    init() {}
+}
+
+private class CountedService {
+    nonisolated(unsafe) private static let _lock = NSLock()
+    nonisolated(unsafe) private static var _count = 0
+    static var creationCount: Int {
+        _lock.lock()
+        defer { _lock.unlock() }
+        return _count
+    }
+    static func resetCount() {
+        _lock.lock()
+        _count = 0
+        _lock.unlock()
+    }
+    init() {
+        CountedService._lock.lock()
+        CountedService._count += 1
+        CountedService._lock.unlock()
+    }
+}
+
+private class GraphParent {
+    let child1: StressService
+    let child2: StressService
+    init(child1: StressService, child2: StressService) {
+        self.child1 = child1
+        self.child2 = child2
+    }
+}
+
+private final class CallCounter: @unchecked Sendable {
+    private let _lock = NSLock()
+    private var _value = 0
+    var value: Int {
+        _lock.lock()
+        defer { _lock.unlock() }
+        return _value
+    }
+    func increment() {
+        _lock.lock()
+        _value += 1
+        _lock.unlock()
+    }
+}


### PR DESCRIPTION
## Summary

This PR eliminates the global recursive lock as a bottleneck during factory resolution. The current implementation holds `globalRecursiveLock` for the entire duration of `resolve()` — including while factory closures execute. This serializes all resolution across all threads, even when factories are independent and cached values are available.

The new design splits resolution into a **fast path** (cache hits, no global lock) and a **slow path** (first resolve only, minimal lock duration), achieving significant throughput improvement on concurrent workloads with realistic factory costs.

## Motivation

In apps with 100+ services resolving at launch across multiple threads (e.g., app startup on modern multi-core devices), the global lock creates a convoy effect: threads queue up waiting for unrelated factories to complete. Every microsecond a factory closure spends reading a config, opening a database, or decoding JSON blocks every other thread in the process from resolving anything.

## Design

### Resolution Plan Cache

On first resolve, a lightweight `ResolutionPlan` struct is built and cached per-key on the `ContainerManager`. Subsequent resolves read the plan under a `CrossPlatformLock` (nanoseconds) and go directly to the scope cache — bypassing the global lock, options dictionary lookups, and registration checks entirely.

Plans are invalidated on any write operation: `.register {}`, `.reset()`, `.decorator()`, `.push()`/`.pop()`, scope changes, and context modifications. A monotonic generation counter prevents stale deferred plan stores from racing with concurrent mutations.

### Lock Hierarchy

```
Fast path:   planLock (CrossPlatformLock) → cache.lock (CrossPlatformLock) → done
Slow path:   globalRecursiveLock → planLock → cache.lock → per-key MutexLock (if singleton/cached)
```

No inversion possible — fast path never touches the global lock, slow path acquires in consistent order.

### Per-Key Creation Locks

Singleton and cached scopes use a per-key `MutexLock` (sleeping, non-recursive) with double-checked locking to guarantee factory-called-once semantics without holding the global lock during factory execution. Creation locks are auto-pruned after use.

### Thread-Local State

- **Graph scope:** Depth counter and graph cache moved to TLS — concurrent resolution cycles no longer interfere.
- **DEBUG state:** Circular dependency tracking and trace resolutions moved to TLS — no contention on debug-only globals.

### `@MainActorLazyInjected`

New lock-free property wrapper for `@MainActor`-isolated types. Omits all locking since main actor isolation already guarantees single-threaded access — zero overhead for the common case of view models and UI services.

This is a pragmatic compromise. Ideally, the `@LazyInjected` macro could inspect the enclosing declaration's actor isolation at compile time and expand to the correct code automatically — no wrapper choice, no lock allocation, no per-access lock overhead. However, Swift macros depend on SwiftSyntax, which significantly increases build times and still has reliability issues with prebuilt binary support. Until the macro ecosystem matures, a separate property wrapper is the simplest correct solution.

### New Lock Backends (prepared, not yet active)

The codebase includes conditional implementations for modern lock primitives behind compiler flags (`SynchronizationLock`, `AllocatedLock`). These are **not enabled** in this PR — SPM package traits cannot conditionally raise the deployment target, so enabling them would either break consumers on older OS versions or require a hard minimum bump. They're ready to activate when Factory's deployment target is raised in a future release.

- **`SynchronizationLock`** — Uses Swift 6 `Mutex` (zero-cost inline lock, requires iOS 18+ / macOS 15+)
- **`AllocatedLock`** — Uses `OSAllocatedUnfairLock` (single allocation, requires iOS 16+ / macOS 13+)
- **Default (active)** — `os_unfair_lock` via `UnsafeMutablePointer` (all OS versions)

## Profiling (Instruments)

Measured with `os_signpost` intervals around `resolve()` and global lock acquisition in a real app resolving ~1,000 factories during launch.

### Baseline (`main`)

<img width="1164" height="293" alt="factory_baseline" src="https://github.com/user-attachments/assets/74e1ae3b-12ec-44b6-b02f-f26b3bf352d8" />

| Metric | Count | Duration | Avg | Max |
|--------|-------|----------|-----|-----|
| Resolve | 1,079 | 1.49 s | 1.38 ms | 51.67 ms |
| Lock Acquire | 1,079 | 667.90 ms | 619.00 µs | 51.67 ms |

### This PR

<img width="1151" height="286" alt="final_results" src="https://github.com/user-attachments/assets/d988be88-6dac-48cb-95dc-30ba41389d53" />

| Metric | Count | Duration | Avg | Max |
|--------|-------|----------|-----|-----|
| Resolve | 1,053 | 1.04 s | 984.79 µs | 30.94 ms |
| Lock Acquire | 519 | 11.19 ms | 21.57 µs | 1.95 ms |

### Key Improvements

- **Lock contention eliminated:** Average lock wait dropped from 619 µs → 21.57 µs (~29× reduction)
- **Tail latency crushed:** Max lock wait dropped from 51.67 ms → 1.95 ms (~26× reduction)
- **Fast path working:** 52% fewer lock acquisitions — cache hits bypass the global lock entirely
- **Total time in locks:** 667.90 ms → 11.19 ms (~60× less time blocked)

## What's Changed

- **Registrations.swift** — Fast path / slow path split in `resolve()`, `ResolutionPlan` struct, generation-guarded deferred plan store for circular dependency safety
- **Scopes.swift** — `Scope.Cache` is now internally synchronized (`CrossPlatformLock` + per-key `MutexLock` for exclusive creation with auto-prune), Graph scope uses TLS
- **Containers.swift** — Plan cache on `ContainerManager` with generation counter, invalidation calls on reset/push/pop/decorator/defaultScope
- **Globals.swift** — `ThreadLocalDebugState` replacing global mutable vars
- **Locking.swift** — `CrossPlatformLock` (renamed from `SpinLock`) with conditional backends (prepared, not active), new `MutexLock` type
- **MainActorInjections.swift** — New `@MainActorLazyInjected` property wrapper (lock-free)
- **Package.swift** — Removed `.dynamic` from FactoryTesting
- **Tests** — Concurrency stress tests

## Breaking Changes

None. Public API is unchanged. Internal behavior is semantically equivalent with the documented eventual-consistency caveat on concurrent registration (which was already racy by design in the original — the global lock only prevented crashes, not deterministic ordering).

## Risks

- **Scope and complexity of change:** This PR touches the core resolution engine. At ~1,000 lines across 8 files, it replaces the single-lock-guards-everything model with a multi-lock design involving plan caches, generation counters, per-key creation locks, and TLS state. Any subtle bug here (missed invalidation, lock ordering issue, race window) could manifest as wrong instances, deadlocks, or crashes in production apps — potentially under load patterns that unit tests don't cover. The existing test suite passes, and new stress tests cover the key invariants, but the nature of concurrency bugs is that they hide.
- **Eventual consistency on concurrent registration:** A `resolve()` in flight during a `.register {}` may return the old value. This was already true before (the global lock prevented crashes but not deterministic ordering of concurrent read/write). Now it's documented explicitly.
- **Circular dependency deadlock in release builds:** Scoped factories (singleton/cached) use non-recursive per-key creation locks. A circular dependency (A → B → A, all singletons) will deadlock the thread. In DEBUG builds, circular dependencies are detected before the per-key lock is acquired. This is acceptable — circular dependencies are always programmer errors, and DEBUG detection covers the development cycle.
- **Plan cache staleness:** If a plan is cached and an external mutation path is missed (i.e., doesn't call `invalidatePlan`/`invalidateAllPlans`), the fast path could serve stale data. Mitigated by invalidating on all known write paths and by the generation counter on deferred stores.

## Testing

- All existing tests pass
- New stress tests verify:
  - Singleton returns same instance across 100 threads
  - Singleton factory executes exactly once under contention
  - Cached scope returns stable instances under contention
  - Graph scope isolates per-thread resolution cycles
  - Decorators added after first resolve fire correctly (plan invalidation)
  - Container-level decorators invalidate plans

## Declaration

The program was tested solely for our own use cases, which might differ from yours.

## Link to provider information

https://github.com/mercedes-benz
